### PR TITLE
Wrap login navigation in startTransition

### DIFF
--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,9 +1,8 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, startTransition } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useAuthStore } from '@/stores/auth'
 import { isOnlineSyncEnabled } from '@/sync/adapter'
 import { db } from '@/db'
-import { seed } from '@/db/seed'
 import { derivePinHash } from '@/utils/pin'
 
 export default function Login() {
@@ -105,7 +104,9 @@ export default function Login() {
         
         if (success) {
           console.log('[login] success - navigating to dashboard')
-          navigate('/')
+          startTransition(() => {
+            navigate('/')
+          })
         } else {
           console.log('[login] failed - invalid PIN')
           setErr('Invalid PIN')


### PR DESCRIPTION
## Summary
- wrap the dashboard navigation after a successful offline login in React's `startTransition`
- remove an unused seed import from the login screen

## Testing
- npm run test:run *(fails: existing predictive queue tests)*

------
https://chatgpt.com/codex/tasks/task_e_68fd3c3a285c8332ba8413a13c161810