### PR TITLE
feat: wire up Supabase + Vercel + GitHub integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,33 @@
-# Optional Supabase configuration for online sync
-# Leave empty to run in offline-only mode
+# ─────────────────────────────────────────────────────────────────────────────
+# MedBridge HealthReach (mBHR) – Environment Variables
+# ─────────────────────────────────────────────────────────────────────────────
+# Copy this file to .env and fill in your values.
+# NEVER commit your real .env file to git.
+#
+# Vercel Supabase Integration (https://vercel.com/integrations/supabase)
+# automatically injects SUPABASE_URL, SUPABASE_ANON_KEY, and
+# SUPABASE_SERVICE_ROLE_KEY into your Vercel project.
+# Add the VITE_ prefixed equivalents below to expose them to the browser.
+# ─────────────────────────────────────────────────────────────────────────────
 
+# ── Supabase ────────────────────────────────────────────────────────────────
+# Required for online sync and authentication.
+# Leave empty to run in offline-only mode.
+#
+# Find these in: Supabase Dashboard → Project Settings → API
 VITE_SUPABASE_URL=
 VITE_SUPABASE_ANON_KEY=
 
-# Optional Sentry error tracking
-# Leave empty to disable error tracking
+# The public URL of your deployed app.
+# Used by Supabase Auth to build email confirmation redirect links.
+# In production this should match your Vercel deployment URL.
+VITE_APP_URL=http://localhost:5173
+
+# ── Sentry error tracking ────────────────────────────────────────────────────
+# Optional. Leave empty to disable.
 # Get your DSN from https://sentry.io/
 VITE_SENTRY_DSN=
 
-# Site configuration
+# ── Site metadata ────────────────────────────────────────────────────────────
 VITE_SITE_NAME="Med Bridge Health Reach"
 VITE_ORGANIZATION="Dr. Isioma Okobah Foundation"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { PWAInstallPrompt } from "@/components/PWAInstallPrompt";
 import { Home } from "@/pages/Home";
 import { startPortalSyncWorker } from "@/services/portalSyncWorker";
 import { supabase, isSupabaseEnabled } from "@/lib/supabaseClient";
+import { AuthCallback } from "@/components/AuthCallback";
 
 // Core pages - loaded eagerly for initial navigation
 const Dashboard = lazy(() =>
@@ -379,6 +380,9 @@ function App() {
         {/* Public Routes - Must be defined before catch-all */}
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
+
+        {/* Supabase auth email-confirmation redirect */}
+        <Route path="/auth/callback" element={<AuthCallback />} />
 
         {/* Patient Portal Routes */}
         <Route path="/patient" element={<PatientPortalLanding />} />

--- a/src/components/AuthCallback.tsx
+++ b/src/components/AuthCallback.tsx
@@ -1,0 +1,90 @@
+/**
+ * AuthCallback
+ *
+ * Handles the redirect that Supabase sends after a user clicks the
+ * email-confirmation link.  Supabase Auth (with detectSessionInUrl: true)
+ * exchanges the URL code/token for a session automatically; this component
+ * just shows a friendly "please wait" screen while that exchange happens and
+ * then navigates to the patient dashboard.
+ *
+ * Route: /auth/callback
+ */
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { supabase } from "@/lib/supabaseClient";
+
+export function AuthCallback() {
+  const navigate   = useNavigate();
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!supabase) {
+      navigate("/patient/login", { replace: true });
+      return;
+    }
+
+    // supabase-js processes the URL hash/code automatically on initialisation.
+    // We listen for the resulting SIGNED_IN event and redirect.
+    const { data: listener } = supabase.auth.onAuthStateChange((event) => {
+      if (event === "SIGNED_IN") {
+        navigate("/patient/dashboard", { replace: true });
+      } else if (event === "TOKEN_REFRESHED") {
+        navigate("/patient/dashboard", { replace: true });
+      }
+    });
+
+    // Also check if there's already an active session (e.g. page was refreshed
+    // after the exchange already completed)
+    supabase.auth.getSession().then(({ data }) => {
+      if (data.session) {
+        navigate("/patient/dashboard", { replace: true });
+      }
+    });
+
+    // Timeout fallback — if nothing happened in 10 s, show an error
+    const timer = setTimeout(() => {
+      setError(
+        "Could not verify your account. The link may have expired. Please try logging in.",
+      );
+    }, 10_000);
+
+    return () => {
+      listener.subscription.unsubscribe();
+      clearTimeout(timer);
+    };
+  }, [navigate]);
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
+        <div className="bg-white rounded-2xl shadow-xl p-8 max-w-md w-full text-center">
+          <div className="w-16 h-16 bg-red-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <span className="text-2xl">✕</span>
+          </div>
+          <h1 className="text-xl font-bold text-gray-900 mb-2">Verification failed</h1>
+          <p className="text-gray-600 mb-6">{error}</p>
+          <button
+            onClick={() => window.location.assign("/patient/login")}
+            className="w-full bg-blue-600 text-white py-3 rounded-lg font-medium hover:bg-blue-700 transition-colors"
+          >
+            Back to Login
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-blue-100 flex items-center justify-center p-4">
+      <div className="bg-white rounded-2xl shadow-xl p-8 max-w-md w-full text-center">
+        <div className="flex justify-center mb-6">
+          <div className="w-14 h-14 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
+        </div>
+        <h1 className="text-xl font-bold text-gray-900 mb-2">Verifying your account…</h1>
+        <p className="text-gray-500 text-sm">
+          Please wait while we confirm your email address.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/patient-portal/PatientDashboard.tsx
+++ b/src/features/patient-portal/PatientDashboard.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
 import {
   CalendarIcon,
@@ -399,7 +400,7 @@ function ErrorCard({ message }: { message: string }) {
 function StatTile({
   icon, bg, label, value, to,
 }: {
-  icon: React.ReactNode; bg: string; label: string; value: number; to: string;
+  icon: ReactNode; bg: string; label: string; value: number; to: string;
 }) {
   return (
     <Link to={to} className="bg-white rounded-xl shadow-sm p-6 hover:shadow-md transition-shadow">

--- a/src/features/patient-portal/PatientDashboard.tsx
+++ b/src/features/patient-portal/PatientDashboard.tsx
@@ -108,14 +108,8 @@ function SupabaseDashboard() {
     setLoading(true);
     setError("");
     try {
-      const [profileRes, vitalsRes, medsRes, visitsRes] = await Promise.all([
-        getPatientProfile(user.id),
-        (async () => { const r = await getPatientProfile(user.id); return r; })(),
-        getMedications(""),
-        getVisits(""),
-      ]);
-
-      // Get profile first, then use its id for other queries
+      // Load profile first so we have the patientId for subsequent queries
+      const profileRes = await getPatientProfile(user.id);
       if (profileRes.error || !profileRes.data) {
         setError("Could not load your profile. Make sure your account is set up.");
         setLoading(false);
@@ -150,7 +144,8 @@ function SupabaseDashboard() {
   if (!profile) return null;
 
   const latest = vitals[0] ?? null;
-  const [bpSys, bpDia] = (latest?.bloodPressure ?? "").split("/").map(Number);
+  const bpSys = latest?.systolic  ?? 0;
+  const bpDia = latest?.diastolic ?? 0;
 
   return (
     <div className="max-w-7xl mx-auto px-4 py-8 space-y-6">
@@ -159,7 +154,7 @@ function SupabaseDashboard() {
         <div className="flex items-start justify-between flex-wrap gap-2">
           <div>
             <h1 className="text-3xl font-bold text-gray-900">
-              Welcome back, {profile.fullName.split(" ")[0]}!
+              Welcome back, {profile.givenName}!
             </h1>
             <p className="text-gray-600 mt-1">Here's an overview of your health information.</p>
           </div>
@@ -193,15 +188,15 @@ function SupabaseDashboard() {
             {bpSys > 0 && bpDia > 0 && (
               <VitalCard label="Blood Pressure" value={`${bpSys}/${bpDia}`} unit="mmHg" status={bpStatus(bpSys)} />
             )}
-            {latest.weight && (
-              <VitalCard label="Weight" value={`${latest.weight}`} unit="kg" status="normal" />
+            {latest.weightKg != null && (
+              <VitalCard label="Weight" value={`${latest.weightKg}`} unit="kg" status="normal" />
             )}
-            {latest.temperature && (
-              <VitalCard label="Temperature" value={`${latest.temperature}°C`} unit="celsius" status={tempStatus(latest.temperature)} />
+            {latest.tempC != null && (
+              <VitalCard label="Temperature" value={`${latest.tempC}°C`} unit="celsius" status={tempStatus(latest.tempC)} />
             )}
           </div>
           <p className="text-xs text-gray-500 mt-4">
-            Recorded: {new Date(latest.recordedAt).toLocaleDateString()}
+            Recorded: {new Date(latest.takenAt).toLocaleDateString()}
           </p>
         </div>
       )}
@@ -222,9 +217,9 @@ function SupabaseDashboard() {
                   <HeartIcon className="w-5 h-5 text-blue-600" />
                 </div>
                 <div>
-                  <p className="font-medium text-gray-900">{med.name}</p>
+                  <p className="font-medium text-gray-900">{med.itemName}</p>
                   <p className="text-sm text-gray-600">{med.dosage}</p>
-                  <p className="text-xs text-gray-500">{med.instructions}</p>
+                  <p className="text-xs text-gray-500">{med.directions}</p>
                 </div>
               </div>
             ))}
@@ -247,7 +242,7 @@ function SupabaseDashboard() {
             {visits.slice(0, 3).map((v) => (
               <div key={v.id} className="p-3 bg-gray-50 rounded-lg">
                 <p className="text-sm font-medium text-gray-900">
-                  {new Date(v.visitDate).toLocaleDateString()}
+                  {new Date(v.startedAt).toLocaleDateString()}
                 </p>
                 {v.diagnosis && <p className="text-xs text-gray-600 mt-1">Diagnosis: {v.diagnosis}</p>}
                 {v.notes && <p className="text-xs text-gray-500 mt-0.5">{v.notes}</p>}

--- a/src/features/patient-portal/PatientRegister.tsx
+++ b/src/features/patient-portal/PatientRegister.tsx
@@ -60,12 +60,17 @@ export function PatientRegister() {
   });
 
   const handleSupabaseRegister = async (data: RegistrationForm) => {
+    const parts      = data.fullName.trim().split(/\s+/);
+    const givenName  = parts[0]          ?? data.fullName;
+    const familyName = parts.slice(1).join(" ") || "";
+
     const authError = await signup({
-      email:       data.email,
-      password:    data.password,
-      fullName:    data.fullName,
-      phone:       data.phone || undefined,
-      dateOfBirth: data.dateOfBirth || undefined,
+      email:      data.email,
+      password:   data.password,
+      givenName,
+      familyName,
+      phone:      data.phone        || undefined,
+      dob:        data.dateOfBirth  || undefined,
     });
     if (authError) {
       const msg = authError.message.toLowerCase();

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,8 +1,10 @@
 /**
  * useAuth – Supabase auth hook for the patient portal.
  *
- * Exposes login, signup, logout, and the current Supabase user/session.
- * Falls back gracefully when Supabase is not configured.
+ * Wraps signInWithPassword, signUp (auto-creates the patients row),
+ * signOut, and exposes live user/session state.
+ * Safe to call when Supabase is not configured — all operations no-op
+ * gracefully so offline mode keeps working.
  */
 import { useState, useEffect, useCallback } from "react";
 import { supabase } from "@/lib/supabaseClient";
@@ -15,9 +17,10 @@ export interface AuthError {
 export interface SignUpData {
   email: string;
   password: string;
-  fullName: string;
+  givenName: string;
+  familyName: string;
   phone?: string;
-  dateOfBirth?: string;
+  dob?: string;
 }
 
 export interface UseAuthReturn {
@@ -31,7 +34,7 @@ export interface UseAuthReturn {
 }
 
 export function useAuth(): UseAuthReturn {
-  const [user, setUser]       = useState<User | null>(null);
+  const [user,    setUser]    = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
 
@@ -41,7 +44,7 @@ export function useAuth(): UseAuthReturn {
       return;
     }
 
-    // Populate from existing session immediately
+    // Prime from existing session immediately (no network call)
     supabase.auth.getSession().then(({ data }) => {
       setSession(data.session);
       setUser(data.session?.user ?? null);
@@ -57,41 +60,58 @@ export function useAuth(): UseAuthReturn {
   }, []);
 
   const login = useCallback(async (email: string, password: string): Promise<AuthError | null> => {
-    if (!supabase) return { message: "Supabase is not configured. Running in offline mode." };
-
+    if (!supabase) return { message: "Supabase is not configured — running in offline mode." };
     const { error } = await supabase.auth.signInWithPassword({ email, password });
     if (error) return { message: error.message };
     return null;
   }, []);
 
   const signup = useCallback(async (data: SignUpData): Promise<AuthError | null> => {
-    if (!supabase) return { message: "Supabase is not configured. Running in offline mode." };
+    if (!supabase) return { message: "Supabase is not configured — running in offline mode." };
 
+    // 1. Create the auth user
     const { data: authData, error: signUpError } = await supabase.auth.signUp({
-      email: data.email,
+      email:    data.email,
       password: data.password,
+      options: {
+        // Pre-populate display name in auth metadata
+        data: { full_name: `${data.givenName} ${data.familyName}`.trim() },
+      },
     });
 
     if (signUpError) return { message: signUpError.message };
-    if (!authData.user) return { message: "Signup succeeded but no user returned." };
+    if (!authData.user) return { message: "Sign-up succeeded but no user was returned." };
 
-    // Insert the patient profile row linked to the new auth user
+    // 2. Insert into the existing `patients` table
+    //    Matches columns from migrations/20250930025202_young_hat.sql +
+    //    20251029000000_add_patient_email_auth_fields.sql
+    const patientId = crypto.randomUUID();
     const { error: insertError } = await supabase.from("patients").insert({
-      auth_user_id:   authData.user.id,
-      full_name:      data.fullName,
-      email:          data.email,
-      phone:          data.phone ?? null,
-      date_of_birth:  data.dateOfBirth ?? null,
+      id:           patientId,
+      auth_uid:     authData.user.id,   // UUID stored as text (existing schema pattern)
+      given_name:   data.givenName,
+      family_name:  data.familyName,
+      email:        data.email,
+      phone:        data.phone ?? null,
+      dob:          data.dob   ?? null,
+      sex:          "other",
+      address:      "",
+      state:        "",
+      lga:          "",
     });
 
-    if (insertError) return { message: insertError.message };
+    if (insertError) {
+      // Auth user was created but patient insert failed.
+      // Surface the error — user can still log in and the profile will be missing.
+      return { message: `Account created but profile save failed: ${insertError.message}` };
+    }
+
     return null;
   }, []);
 
   const logout = useCallback(async () => {
-    if (!supabase) return;
-    await supabase.auth.signOut();
-    // Also clear legacy localStorage keys left by the old offline auth
+    if (supabase) await supabase.auth.signOut();
+    // Clear legacy localStorage keys from the old offline auth system
     localStorage.removeItem("patient_session_token");
     localStorage.removeItem("patient_portal_user");
     localStorage.removeItem("patient_active_profile");

--- a/src/pages/staff/StaffPatientDashboard.tsx
+++ b/src/pages/staff/StaffPatientDashboard.tsx
@@ -393,7 +393,7 @@ export function StaffPatientDashboard() {
   const filtered = patients.filter((p) => {
     const q = search.toLowerCase();
     return (
-      p.fullName.toLowerCase().includes(q) ||
+      `${p.givenName} ${p.familyName}`.toLowerCase().includes(q) ||
       (p.email ?? "").toLowerCase().includes(q) ||
       (p.phone ?? "").includes(q)
     );

--- a/src/pages/staff/StaffPatientDashboard.tsx
+++ b/src/pages/staff/StaffPatientDashboard.tsx
@@ -54,10 +54,13 @@ function AddVitalForm({
     e.preventDefault();
     setLoading(true);
     setError("");
+    // Parse "120/80" format into systolic/diastolic
+    const [sysStr, diaStr] = (bp || "").split("/");
     const result = await addVital(patientId, {
-      bloodPressure: bp   || null,
-      weight:        wt   ? parseFloat(wt)   : null,
-      temperature:   temp ? parseFloat(temp) : null,
+      bloodPressureSystolic:  sysStr ? parseInt(sysStr, 10) : null,
+      bloodPressureDiastolic: diaStr ? parseInt(diaStr, 10) : null,
+      weightKg:    wt   ? parseFloat(wt)   : null,
+      tempC:       temp ? parseFloat(temp) : null,
     });
     setLoading(false);
     if (result.error) {
@@ -109,7 +112,7 @@ function AddMedForm({
     setError("");
     const result = await addMedication(patientId, {
       name, dosage: dose || null, instructions: instr || null,
-    });
+    } as { name: string; dosage?: string | null; instructions?: string | null });
     setLoading(false);
     if (result.error) {
       setError(result.error);
@@ -259,10 +262,10 @@ function PatientPanel({ patient }: { patient: PatientProfile }) {
             <ul className="space-y-2 text-xs text-gray-700">
               {vitals.slice(0, 3).map((v) => (
                 <li key={v.id} className="bg-white rounded p-2">
-                  {v.bloodPressure && <p>BP: {v.bloodPressure}</p>}
-                  {v.weight        && <p>Wt: {v.weight} kg</p>}
-                  {v.temperature   && <p>Temp: {v.temperature}°C</p>}
-                  <p className="text-gray-400">{new Date(v.recordedAt).toLocaleDateString()}</p>
+                  {v.systolic != null && v.diastolic != null && <p>BP: {v.systolic}/{v.diastolic} mmHg</p>}
+                  {v.weightKg  != null && <p>Wt: {v.weightKg} kg</p>}
+                  {v.tempC     != null && <p>Temp: {v.tempC}°C</p>}
+                  <p className="text-gray-400">{new Date(v.takenAt).toLocaleDateString()}</p>
                 </li>
               ))}
             </ul>
@@ -278,9 +281,9 @@ function PatientPanel({ patient }: { patient: PatientProfile }) {
             <ul className="space-y-2 text-xs text-gray-700">
               {medications.slice(0, 3).map((m) => (
                 <li key={m.id} className="bg-white rounded p-2">
-                  <p className="font-medium">{m.name}</p>
-                  {m.dosage       && <p>{m.dosage}</p>}
-                  {m.instructions && <p className="text-gray-400">{m.instructions}</p>}
+                  <p className="font-medium">{m.itemName}</p>
+                  {m.dosage     && <p>{m.dosage}</p>}
+                  {m.directions && <p className="text-gray-400">{m.directions}</p>}
                 </li>
               ))}
             </ul>
@@ -296,7 +299,7 @@ function PatientPanel({ patient }: { patient: PatientProfile }) {
             <ul className="space-y-2 text-xs text-gray-700">
               {visits.slice(0, 3).map((v) => (
                 <li key={v.id} className="bg-white rounded p-2">
-                  <p className="font-medium">{new Date(v.visitDate).toLocaleDateString()}</p>
+                  <p className="font-medium">{new Date(v.startedAt).toLocaleDateString()}</p>
                   {v.diagnosis && <p>Dx: {v.diagnosis}</p>}
                   {v.notes     && <p className="text-gray-400 truncate">{v.notes}</p>}
                 </li>
@@ -323,18 +326,18 @@ function PatientRow({ patient }: { patient: PatientProfile }) {
         <div className="flex items-center gap-4">
           <div className="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center">
             <span className="text-blue-700 font-bold text-sm">
-              {patient.fullName.charAt(0).toUpperCase()}
+              {patient.givenName.charAt(0).toUpperCase()}
             </span>
           </div>
           <div>
-            <p className="font-semibold text-gray-900">{patient.fullName}</p>
+            <p className="font-semibold text-gray-900">{patient.givenName} {patient.familyName}</p>
             <p className="text-sm text-gray-500">{patient.email ?? "No email"}</p>
           </div>
         </div>
         <div className="flex items-center gap-4">
-          {patient.dateOfBirth && (
+          {patient.dob && (
             <span className="text-xs text-gray-400 hidden md:block">
-              DOB: {patient.dateOfBirth}
+              DOB: {patient.dob}
             </span>
           )}
           {expanded

--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -1,49 +1,63 @@
 /**
- * Patient Service – abstraction layer over Supabase for patient-facing data.
+ * Patient Service – abstracts all Supabase data access.
  *
- * All UI components should call these functions rather than querying Supabase
- * directly.  This keeps the Supabase dependency in one place and makes it
- * straightforward to add local caching or offline queuing later.
+ * Maps to the EXISTING Supabase schema (patients, vitals, consultations,
+ * dispenses, visits tables created by the initial migrations).
+ * Column names match the snake_case columns already in the database.
  */
 import { supabase } from "@/lib/supabaseClient";
 import * as logger from "@/lib/logger";
 
-// ─── Types ────────────────────────────────────────────────────────────────────
+// ─── Domain types (camelCase for the app) ─────────────────────────────────────
 
 export interface PatientProfile {
-  id: string;
-  authUserId: string;
-  fullName: string;
+  id: string;           // text pk
+  authUid: string | null;
+  givenName: string;
+  familyName: string;
   email: string | null;
   phone: string | null;
-  dateOfBirth: string | null;
+  dob: string | null;
+  sex: string | null;
   createdAt: string;
 }
 
-export interface Visit {
-  id: string;
-  patientId: string;
-  visitDate: string;
-  notes: string | null;
-  diagnosis: string | null;
-}
-
-export interface Medication {
-  id: string;
-  patientId: string;
-  name: string;
-  dosage: string | null;
-  instructions: string | null;
-  createdAt: string;
-}
-
+/** Vitals row from the existing `vitals` table */
 export interface Vital {
   id: string;
   patientId: string;
-  bloodPressure: string | null;
-  weight: number | null;
-  temperature: number | null;
-  recordedAt: string;
+  visitId: string | null;
+  heightCm: number | null;
+  weightKg: number | null;
+  tempC: number | null;
+  pulseBpm: number | null;
+  systolic: number | null;
+  diastolic: number | null;
+  spo2: number | null;
+  bmi: number | null;
+  takenAt: string;
+}
+
+/** Maps to the `dispenses` table (medications dispensed to a patient) */
+export interface Medication {
+  id: string;
+  patientId: string;
+  visitId: string | null;
+  itemName: string;
+  dosage: string | null;
+  directions: string | null;
+  dispensedAt: string;
+}
+
+/** Maps to `visits` joined with the latest `consultations` row for that visit */
+export interface Visit {
+  id: string;
+  patientId: string;
+  startedAt: string;
+  siteName: string | null;
+  status: string;
+  diagnosis: string | null;    // from consultations.soap_assessment
+  notes: string | null;        // from consultations.soap_subjective
 }
 
 export interface ServiceResult<T> {
@@ -51,71 +65,67 @@ export interface ServiceResult<T> {
   error: string | null;
 }
 
-// ─── Profile ─────────────────────────────────────────────────────────────────
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
-export async function getPatientProfile(authUserId: string): Promise<ServiceResult<PatientProfile>> {
+function rowToProfile(r: Record<string, unknown>): PatientProfile {
+  return {
+    id:         r.id           as string,
+    authUid:    r.auth_uid     as string | null,
+    givenName:  r.given_name   as string,
+    familyName: r.family_name  as string,
+    email:      r.email        as string | null,
+    phone:      r.phone        as string | null,
+    dob:        r.dob          as string | null,
+    sex:        r.sex          as string | null,
+    createdAt:  r.created_at   as string,
+  };
+}
+
+// ─── Patient profile ──────────────────────────────────────────────────────────
+
+/** Fetch a patient by their Supabase auth UID (stored as text in auth_uid). */
+export async function getPatientProfile(authUid: string): Promise<ServiceResult<PatientProfile>> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
 
   const { data, error } = await supabase
     .from("patients")
-    .select("*")
-    .eq("auth_user_id", authUserId)
-    .single();
+    .select("id, auth_uid, given_name, family_name, email, phone, dob, sex, created_at")
+    .eq("auth_uid", authUid)
+    .maybeSingle();
 
   if (error) {
     logger.error("[patientService] getPatientProfile:", error.message);
     return { data: null, error: error.message };
   }
+  if (!data) return { data: null, error: "No patient profile found for this account." };
 
-  return {
-    data: {
-      id:           data.id,
-      authUserId:   data.auth_user_id,
-      fullName:     data.full_name,
-      email:        data.email,
-      phone:        data.phone,
-      dateOfBirth:  data.date_of_birth,
-      createdAt:    data.created_at,
-    },
-    error: null,
-  };
+  return { data: rowToProfile(data), error: null };
 }
 
 export async function updatePatientProfile(
   patientId: string,
-  updates: Partial<Pick<PatientProfile, "fullName" | "phone" | "dateOfBirth">>,
+  updates: Partial<Pick<PatientProfile, "givenName" | "familyName" | "phone" | "dob">>,
 ): Promise<ServiceResult<PatientProfile>> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
 
-  const payload: Record<string, unknown> = {};
-  if (updates.fullName   !== undefined) payload.full_name      = updates.fullName;
-  if (updates.phone      !== undefined) payload.phone          = updates.phone;
-  if (updates.dateOfBirth !== undefined) payload.date_of_birth = updates.dateOfBirth;
+  const payload: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (updates.givenName  !== undefined) payload.given_name  = updates.givenName;
+  if (updates.familyName !== undefined) payload.family_name = updates.familyName;
+  if (updates.phone      !== undefined) payload.phone       = updates.phone;
+  if (updates.dob        !== undefined) payload.dob         = updates.dob;
 
   const { data, error } = await supabase
     .from("patients")
     .update(payload)
     .eq("id", patientId)
-    .select()
+    .select("id, auth_uid, given_name, family_name, email, phone, dob, sex, created_at")
     .single();
 
   if (error) {
     logger.error("[patientService] updatePatientProfile:", error.message);
     return { data: null, error: error.message };
   }
-
-  return {
-    data: {
-      id:           data.id,
-      authUserId:   data.auth_user_id,
-      fullName:     data.full_name,
-      email:        data.email,
-      phone:        data.phone,
-      dateOfBirth:  data.date_of_birth,
-      createdAt:    data.created_at,
-    },
-    error: null,
-  };
+  return { data: rowToProfile(data), error: null };
 }
 
 // ─── Vitals ───────────────────────────────────────────────────────────────────
@@ -125,9 +135,9 @@ export async function getVitals(patientId: string): Promise<ServiceResult<Vital[
 
   const { data, error } = await supabase
     .from("vitals")
-    .select("*")
+    .select("id, patient_id, visit_id, height_cm, weight_kg, temp_c, pulse_bpm, systolic, diastolic, spo2, bmi, taken_at")
     .eq("patient_id", patientId)
-    .order("recorded_at", { ascending: false });
+    .order("taken_at", { ascending: false });
 
   if (error) {
     logger.error("[patientService] getVitals:", error.message);
@@ -136,12 +146,18 @@ export async function getVitals(patientId: string): Promise<ServiceResult<Vital[
 
   return {
     data: (data || []).map((v) => ({
-      id:            v.id,
-      patientId:     v.patient_id,
-      bloodPressure: v.blood_pressure,
-      weight:        v.weight,
-      temperature:   v.temperature,
-      recordedAt:    v.recorded_at,
+      id:        v.id,
+      patientId: v.patient_id,
+      visitId:   v.visit_id,
+      heightCm:  v.height_cm,
+      weightKg:  v.weight_kg,
+      tempC:     v.temp_c,
+      pulseBpm:  v.pulse_bpm,
+      systolic:  v.systolic,
+      diastolic: v.diastolic,
+      spo2:      v.spo2,
+      bmi:       v.bmi,
+      takenAt:   v.taken_at,
     })),
     error: null,
   };
@@ -149,17 +165,34 @@ export async function getVitals(patientId: string): Promise<ServiceResult<Vital[
 
 export async function addVital(
   patientId: string,
-  vital: Pick<Vital, "bloodPressure" | "weight" | "temperature">,
+  vital: {
+    bloodPressureSystolic?: number | null;
+    bloodPressureDiastolic?: number | null;
+    weightKg?: number | null;
+    tempC?: number | null;
+    pulseBpm?: number | null;
+    spo2?: number | null;
+    heightCm?: number | null;
+  },
 ): Promise<ServiceResult<Vital>> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
+
+  const id = crypto.randomUUID();
 
   const { data, error } = await supabase
     .from("vitals")
     .insert({
-      patient_id:     patientId,
-      blood_pressure: vital.bloodPressure,
-      weight:         vital.weight,
-      temperature:    vital.temperature,
+      id,
+      patient_id: patientId,
+      systolic:   vital.bloodPressureSystolic  ?? null,
+      diastolic:  vital.bloodPressureDiastolic ?? null,
+      weight_kg:  vital.weightKg  ?? null,
+      temp_c:     vital.tempC     ?? null,
+      pulse_bpm:  vital.pulseBpm  ?? null,
+      spo2:       vital.spo2      ?? null,
+      height_cm:  vital.heightCm  ?? null,
+      taken_at:   new Date().toISOString(),
+      flags:      [],
     })
     .select()
     .single();
@@ -171,27 +204,33 @@ export async function addVital(
 
   return {
     data: {
-      id:            data.id,
-      patientId:     data.patient_id,
-      bloodPressure: data.blood_pressure,
-      weight:        data.weight,
-      temperature:   data.temperature,
-      recordedAt:    data.recorded_at,
+      id:        data.id,
+      patientId: data.patient_id,
+      visitId:   data.visit_id,
+      heightCm:  data.height_cm,
+      weightKg:  data.weight_kg,
+      tempC:     data.temp_c,
+      pulseBpm:  data.pulse_bpm,
+      systolic:  data.systolic,
+      diastolic: data.diastolic,
+      spo2:      data.spo2,
+      bmi:       data.bmi,
+      takenAt:   data.taken_at,
     },
     error: null,
   };
 }
 
-// ─── Medications ──────────────────────────────────────────────────────────────
+// ─── Medications (dispenses) ──────────────────────────────────────────────────
 
 export async function getMedications(patientId: string): Promise<ServiceResult<Medication[]>> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
 
   const { data, error } = await supabase
-    .from("medications")
-    .select("*")
+    .from("dispenses")
+    .select("id, patient_id, visit_id, item_name, dosage, directions, dispensed_at")
     .eq("patient_id", patientId)
-    .order("created_at", { ascending: false });
+    .order("dispensed_at", { ascending: false });
 
   if (error) {
     logger.error("[patientService] getMedications:", error.message);
@@ -200,12 +239,13 @@ export async function getMedications(patientId: string): Promise<ServiceResult<M
 
   return {
     data: (data || []).map((m) => ({
-      id:           m.id,
-      patientId:    m.patient_id,
-      name:         m.name,
-      dosage:       m.dosage,
-      instructions: m.instructions,
-      createdAt:    m.created_at,
+      id:          m.id,
+      patientId:   m.patient_id,
+      visitId:     m.visit_id,
+      itemName:    m.item_name,
+      dosage:      m.dosage,
+      directions:  m.directions,
+      dispensedAt: m.dispensed_at,
     })),
     error: null,
   };
@@ -213,17 +253,23 @@ export async function getMedications(patientId: string): Promise<ServiceResult<M
 
 export async function addMedication(
   patientId: string,
-  med: Pick<Medication, "name" | "dosage" | "instructions">,
+  med: { name: string; dosage?: string | null; instructions?: string | null },
 ): Promise<ServiceResult<Medication>> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
 
+  const id = crypto.randomUUID();
+
   const { data, error } = await supabase
-    .from("medications")
+    .from("dispenses")
     .insert({
+      id,
       patient_id:   patientId,
-      name:         med.name,
-      dosage:       med.dosage,
-      instructions: med.instructions,
+      item_name:    med.name,
+      dosage:       med.dosage       ?? null,
+      directions:   med.instructions ?? null,
+      qty:          1,
+      dispensed_by: "staff",
+      dispensed_at: new Date().toISOString(),
     })
     .select()
     .single();
@@ -235,12 +281,13 @@ export async function addMedication(
 
   return {
     data: {
-      id:           data.id,
-      patientId:    data.patient_id,
-      name:         data.name,
-      dosage:       data.dosage,
-      instructions: data.instructions,
-      createdAt:    data.created_at,
+      id:          data.id,
+      patientId:   data.patient_id,
+      visitId:     data.visit_id,
+      itemName:    data.item_name,
+      dosage:      data.dosage,
+      directions:  data.directions,
+      dispensedAt: data.dispensed_at,
     },
     error: null,
   };
@@ -253,9 +300,12 @@ export async function getVisits(patientId: string): Promise<ServiceResult<Visit[
 
   const { data, error } = await supabase
     .from("visits")
-    .select("*")
+    .select(`
+      id, patient_id, started_at, site_name, status,
+      consultations ( soap_assessment, soap_subjective )
+    `)
     .eq("patient_id", patientId)
-    .order("visit_date", { ascending: false });
+    .order("started_at", { ascending: false });
 
   if (error) {
     logger.error("[patientService] getVisits:", error.message);
@@ -263,45 +313,67 @@ export async function getVisits(patientId: string): Promise<ServiceResult<Visit[
   }
 
   return {
-    data: (data || []).map((v) => ({
-      id:        v.id,
-      patientId: v.patient_id,
-      visitDate: v.visit_date,
-      notes:     v.notes,
-      diagnosis: v.diagnosis,
-    })),
+    data: (data || []).map((v) => {
+      const consult = Array.isArray(v.consultations) ? v.consultations[0] : v.consultations;
+      return {
+        id:         v.id,
+        patientId:  v.patient_id,
+        startedAt:  v.started_at,
+        siteName:   v.site_name,
+        status:     v.status,
+        diagnosis:  consult?.soap_assessment ?? null,
+        notes:      consult?.soap_subjective ?? null,
+      };
+    }),
     error: null,
   };
 }
 
 export async function addVisit(
   patientId: string,
-  visit: Pick<Visit, "notes" | "diagnosis">,
+  visit: { notes?: string | null; diagnosis?: string | null; siteName?: string },
 ): Promise<ServiceResult<Visit>> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
 
-  const { data, error } = await supabase
-    .from("visits")
-    .insert({
-      patient_id: patientId,
-      notes:      visit.notes,
-      diagnosis:  visit.diagnosis,
-    })
-    .select()
-    .single();
+  const visitId = crypto.randomUUID();
 
-  if (error) {
-    logger.error("[patientService] addVisit:", error.message);
-    return { data: null, error: error.message };
+  // Create the visit row
+  const { error: visitError } = await supabase.from("visits").insert({
+    id:         visitId,
+    patient_id: patientId,
+    started_at: new Date().toISOString(),
+    site_name:  visit.siteName ?? "Portal entry",
+    status:     "closed",
+  });
+  if (visitError) {
+    logger.error("[patientService] addVisit (visit):", visitError.message);
+    return { data: null, error: visitError.message };
+  }
+
+  // If there are notes/diagnosis, create a consultation record too
+  if (visit.notes || visit.diagnosis) {
+    await supabase.from("consultations").insert({
+      id:               crypto.randomUUID(),
+      patient_id:       patientId,
+      visit_id:         visitId,
+      provider_name:    "Staff (portal)",
+      soap_subjective:  visit.notes      ?? "",
+      soap_objective:   "",
+      soap_assessment:  visit.diagnosis  ?? "",
+      soap_plan:        "",
+      provisional_dx:   [],
+    });
   }
 
   return {
     data: {
-      id:        data.id,
-      patientId: data.patient_id,
-      visitDate: data.visit_date,
-      notes:     data.notes,
-      diagnosis: data.diagnosis,
+      id:        visitId,
+      patientId,
+      startedAt: new Date().toISOString(),
+      siteName:  visit.siteName ?? "Portal entry",
+      status:    "closed",
+      diagnosis: visit.diagnosis ?? null,
+      notes:     visit.notes    ?? null,
     },
     error: null,
   };
@@ -314,7 +386,7 @@ export async function getAllPatients(): Promise<ServiceResult<PatientProfile[]>>
 
   const { data, error } = await supabase
     .from("patients")
-    .select("*")
+    .select("id, auth_uid, given_name, family_name, email, phone, dob, sex, created_at")
     .order("created_at", { ascending: false });
 
   if (error) {
@@ -322,16 +394,5 @@ export async function getAllPatients(): Promise<ServiceResult<PatientProfile[]>>
     return { data: null, error: error.message };
   }
 
-  return {
-    data: (data || []).map((p) => ({
-      id:           p.id,
-      authUserId:   p.auth_user_id,
-      fullName:     p.full_name,
-      email:        p.email,
-      phone:        p.phone,
-      dateOfBirth:  p.date_of_birth,
-      createdAt:    p.created_at,
-    })),
-    error: null,
-  };
+  return { data: (data || []).map(rowToProfile), error: null };
 }

--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -302,10 +302,11 @@ export async function getVisits(patientId: string): Promise<ServiceResult<Visit[
     .from("visits")
     .select(`
       id, patient_id, started_at, site_name, status,
-      consultations ( soap_assessment, soap_subjective )
+      consultations ( soap_assessment, soap_subjective, created_at )
     `)
     .eq("patient_id", patientId)
-    .order("started_at", { ascending: false });
+    .order("started_at", { ascending: false })
+    .order("created_at", { referencedTable: "consultations", ascending: false });
 
   if (error) {
     logger.error("[patientService] getVisits:", error.message);
@@ -352,7 +353,7 @@ export async function addVisit(
 
   // If there are notes/diagnosis, create a consultation record too
   if (visit.notes || visit.diagnosis) {
-    await supabase.from("consultations").insert({
+    const { error: consultError } = await supabase.from("consultations").insert({
       id:               crypto.randomUUID(),
       patient_id:       patientId,
       visit_id:         visitId,
@@ -363,6 +364,10 @@ export async function addVisit(
       soap_plan:        "",
       provisional_dx:   [],
     });
+    if (consultError) {
+      logger.error("[patientService] addVisit (consultation):", consultError.message);
+      return { data: null, error: `Visit was saved but clinical notes failed: ${consultError.message}` };
+    }
   }
 
   return {

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,63 @@
+# Supabase CLI project configuration
+# https://supabase.com/docs/guides/cli/config
+#
+# To find your project_id:
+#   supabase projects list
+# Then replace the placeholder below and commit the file.
+
+project_id = "your-supabase-project-id"
+
+[api]
+# The port the local API gateway listens on
+port = 54321
+schemas = ["public", "storage", "graphql_public"]
+extra_search_path = ["public", "extensions"]
+max_rows = 1000
+
+[db]
+# Local Postgres port (used by supabase start)
+port = 54322
+pool_mode = "transaction"
+[db.pooler]
+enabled = false
+
+[realtime]
+enabled = true
+
+[studio]
+enabled = true
+port = 54323
+api_url = "http://127.0.0.1"
+
+[inbucket]
+enabled = true
+port = 54324
+
+[storage]
+enabled = true
+
+[auth]
+# The URL that Supabase Auth redirects to after email confirmation.
+# Set this to your Vercel deployment URL in production.
+site_url = "http://localhost:5173"
+additional_redirect_urls = [
+  "http://localhost:5173/auth/callback",
+  "https://*.vercel.app/auth/callback",
+]
+jwt_expiry = 3600
+enable_refresh_token_rotation = true
+enable_signup = true
+
+[auth.email]
+enable_signup = true
+double_confirm_changes = true
+enable_confirmations = true
+
+[auth.sms]
+enable_signup = false
+
+[edge_runtime]
+enabled = true
+
+[analytics]
+enabled = false

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -5,7 +5,7 @@
 #   supabase projects list
 # Then replace the placeholder below and commit the file.
 
-project_id = "your-supabase-project-id"
+project_id = "xxbbafonflieyqcwaeyx"
 
 [api]
 # The port the local API gateway listens on

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -17,7 +17,6 @@ max_rows = 1000
 [db]
 # Local Postgres port (used by supabase start)
 port = 54322
-pool_mode = "transaction"
 [db.pooler]
 enabled = false
 

--- a/supabase/migrations/20250930125054_teal_coral.sql
+++ b/supabase/migrations/20250930125054_teal_coral.sql
@@ -48,7 +48,7 @@ CREATE POLICY "Users can read own sessions"
   TO authenticated
   USING (auth.uid()::text = volunteer_id OR EXISTS (
     SELECT 1 FROM app_users 
-    WHERE id = auth.uid() AND (admin_access = true OR role IN ('admin', 'doctor', 'nurse'))
+    WHERE id = auth.uid()::text AND (admin_access = true OR role IN ('admin', 'doctor', 'nurse'))
   ));
 
 CREATE POLICY "Admins can approve sessions"
@@ -57,7 +57,7 @@ CREATE POLICY "Admins can approve sessions"
   TO authenticated
   USING (EXISTS (
     SELECT 1 FROM app_users 
-    WHERE id = auth.uid() AND (admin_access = true OR role = 'admin')
+    WHERE id = auth.uid()::text AND (admin_access = true OR role = 'admin')
   ));
 
 -- Gamification wallets table
@@ -92,7 +92,7 @@ CREATE POLICY "Admins can read all wallets"
   TO authenticated
   USING (EXISTS (
     SELECT 1 FROM app_users 
-    WHERE id = auth.uid() AND (admin_access = true OR role = 'admin')
+    WHERE id = auth.uid()::text AND (admin_access = true OR role = 'admin')
   ));
 
 -- Vitals ranges reference table
@@ -160,7 +160,7 @@ CREATE POLICY "Doctors can create triage samples"
   TO authenticated
   WITH CHECK (EXISTS (
     SELECT 1 FROM app_users 
-    WHERE id = auth.uid() AND role IN ('doctor', 'admin')
+    WHERE id = auth.uid()::text AND role IN ('doctor', 'admin')
   ));
 
 -- Inventory discrepancies table

--- a/supabase/migrations/20251024000000_add_advanced_features.sql
+++ b/supabase/migrations/20251024000000_add_advanced_features.sql
@@ -190,7 +190,7 @@ CREATE POLICY "Pharmacists and admins can view reminders"
   ON medication_reminders FOR SELECT
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')
     )
   );
@@ -199,7 +199,7 @@ CREATE POLICY "Pharmacists and admins can create reminders"
   ON medication_reminders FOR INSERT
   TO authenticated
   WITH CHECK (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')
     )
   );
@@ -208,7 +208,7 @@ CREATE POLICY "Pharmacists and admins can update reminders"
   ON medication_reminders FOR UPDATE
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')
     )
   );
@@ -223,7 +223,7 @@ CREATE POLICY "Doctors and nurses can create lab orders"
   ON lab_orders FOR INSERT
   TO authenticated
   WITH CHECK (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('doctor', 'nurse', 'admin')
     )
   );
@@ -232,7 +232,7 @@ CREATE POLICY "Doctors and nurses can update lab orders"
   ON lab_orders FOR UPDATE
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('doctor', 'nurse', 'admin')
     )
   );
@@ -247,7 +247,7 @@ CREATE POLICY "Authorized staff can create lab results"
   ON lab_results FOR INSERT
   TO authenticated
   WITH CHECK (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('doctor', 'nurse', 'admin')
     )
   );
@@ -256,7 +256,7 @@ CREATE POLICY "Authorized staff can update lab results"
   ON lab_results FOR UPDATE
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('doctor', 'nurse', 'admin')
     )
   );
@@ -271,7 +271,7 @@ CREATE POLICY "Staff can create appointments"
   ON appointments FOR INSERT
   TO authenticated
   WITH CHECK (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('chw', 'nurse', 'doctor', 'admin')
     )
   );
@@ -280,7 +280,7 @@ CREATE POLICY "Staff can update appointments"
   ON appointments FOR UPDATE
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('chw', 'nurse', 'doctor', 'admin')
     )
   );
@@ -295,7 +295,7 @@ CREATE POLICY "Staff can create waitlist entries"
   ON waitlist FOR INSERT
   TO authenticated
   WITH CHECK (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('chw', 'nurse', 'doctor', 'admin')
     )
   );
@@ -304,7 +304,7 @@ CREATE POLICY "Staff can update waitlist entries"
   ON waitlist FOR UPDATE
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('chw', 'nurse', 'doctor', 'admin')
     )
   );

--- a/supabase/migrations/20251024000000_add_advanced_features.sql
+++ b/supabase/migrations/20251024000000_add_advanced_features.sql
@@ -97,8 +97,8 @@
 -- medication_reminders table
 CREATE TABLE IF NOT EXISTS medication_reminders (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  dispense_id uuid REFERENCES dispenses(id) ON DELETE CASCADE,
-  patient_id uuid REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
+  dispense_id text REFERENCES dispenses(id) ON DELETE CASCADE,
+  patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
   medication_name text NOT NULL,
   dosage text NOT NULL,
   scheduled_at timestamptz NOT NULL,
@@ -114,9 +114,9 @@ CREATE TABLE IF NOT EXISTS medication_reminders (
 -- lab_orders table
 CREATE TABLE IF NOT EXISTS lab_orders (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
-  visit_id uuid REFERENCES visits(id) ON DELETE SET NULL,
-  ordered_by uuid REFERENCES app_users(id) ON DELETE SET NULL NOT NULL,
+  patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
+  visit_id text REFERENCES visits(id) ON DELETE SET NULL,
+  ordered_by text REFERENCES app_users(id) ON DELETE SET NULL NOT NULL,
   test_name text NOT NULL,
   test_code text,
   priority text NOT NULL CHECK (priority IN ('routine', 'urgent', 'stat')) DEFAULT 'routine',
@@ -140,7 +140,7 @@ CREATE TABLE IF NOT EXISTS lab_results (
   reference_range text,
   interpretation text NOT NULL CHECK (interpretation IN ('normal', 'abnormal', 'critical')) DEFAULT 'normal',
   result_date timestamptz NOT NULL DEFAULT now(),
-  reviewed_by uuid REFERENCES app_users(id) ON DELETE SET NULL,
+  reviewed_by text REFERENCES app_users(id) ON DELETE SET NULL,
   reviewed_at timestamptz,
   notes text,
   created_at timestamptz NOT NULL DEFAULT now(),
@@ -150,8 +150,8 @@ CREATE TABLE IF NOT EXISTS lab_results (
 -- appointments table
 CREATE TABLE IF NOT EXISTS appointments (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
-  provider_id uuid REFERENCES app_users(id) ON DELETE SET NULL,
+  patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
+  provider_id text REFERENCES app_users(id) ON DELETE SET NULL,
   appointment_type text NOT NULL,
   scheduled_at timestamptz NOT NULL,
   duration_minutes integer NOT NULL DEFAULT 30,
@@ -160,7 +160,7 @@ CREATE TABLE IF NOT EXISTS appointments (
   notes text,
   reminder_sent boolean NOT NULL DEFAULT false,
   reminder_sent_at timestamptz,
-  created_by uuid REFERENCES app_users(id) ON DELETE SET NULL NOT NULL,
+  created_by text REFERENCES app_users(id) ON DELETE SET NULL NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );
@@ -168,7 +168,7 @@ CREATE TABLE IF NOT EXISTS appointments (
 -- waitlist table
 CREATE TABLE IF NOT EXISTS waitlist (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
+  patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
   appointment_type text NOT NULL,
   preferred_dates jsonb,
   reason text,

--- a/supabase/migrations/20251024080033_add_missing_advanced_tables.sql
+++ b/supabase/migrations/20251024080033_add_missing_advanced_tables.sql
@@ -392,7 +392,7 @@ CREATE POLICY "Admins can manage users"
   USING (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid() AND app_users.role = 'admin'
+      WHERE app_users.id = auth.uid()::text AND app_users.role = 'admin'
     )
   );
 
@@ -403,7 +403,7 @@ CREATE POLICY "Clinical staff can manage medication reminders"
   USING (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid()
+      WHERE app_users.id = auth.uid()::text
       AND app_users.role IN ('admin', 'doctor', 'nurse', 'pharmacist')
     )
   );
@@ -415,7 +415,7 @@ CREATE POLICY "Clinical staff can manage lab orders"
   USING (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid()
+      WHERE app_users.id = auth.uid()::text
       AND app_users.role IN ('admin', 'doctor', 'nurse')
     )
   );
@@ -427,7 +427,7 @@ CREATE POLICY "Clinical staff can manage lab results"
   USING (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid()
+      WHERE app_users.id = auth.uid()::text
       AND app_users.role IN ('admin', 'doctor', 'nurse')
     )
   );
@@ -451,7 +451,7 @@ CREATE POLICY "Pharmacists can manage stock batches"
   USING (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid()
+      WHERE app_users.id = auth.uid()::text
       AND app_users.role IN ('admin', 'pharmacist')
     )
   );
@@ -463,7 +463,7 @@ CREATE POLICY "Clinical staff can manage care tasks"
   USING (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid()
+      WHERE app_users.id = auth.uid()::text
       AND app_users.role IN ('admin', 'doctor', 'nurse')
     )
   );
@@ -475,7 +475,7 @@ CREATE POLICY "Clinical staff can manage triage records"
   USING (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid()
+      WHERE app_users.id = auth.uid()::text
       AND app_users.role IN ('admin', 'doctor', 'nurse')
     )
   );
@@ -487,7 +487,7 @@ CREATE POLICY "Clinical staff can view allergies"
   USING (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid()
+      WHERE app_users.id = auth.uid()::text
       AND app_users.role IN ('admin', 'doctor', 'nurse', 'pharmacist')
     )
   );
@@ -498,7 +498,7 @@ CREATE POLICY "Clinical staff can manage allergies"
   WITH CHECK (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid()
+      WHERE app_users.id = auth.uid()::text
       AND app_users.role IN ('admin', 'doctor', 'nurse')
     )
   );
@@ -509,14 +509,14 @@ CREATE POLICY "Clinical staff can update allergies"
   USING (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid()
+      WHERE app_users.id = auth.uid()::text
       AND app_users.role IN ('admin', 'doctor', 'nurse')
     )
   )
   WITH CHECK (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid()
+      WHERE app_users.id = auth.uid()::text
       AND app_users.role IN ('admin', 'doctor', 'nurse')
     )
   );
@@ -528,7 +528,7 @@ CREATE POLICY "Staff can manage patient preferences"
   USING (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid()
+      WHERE app_users.id = auth.uid()::text
     )
   );
 
@@ -539,7 +539,7 @@ CREATE POLICY "Admins can view patient merges"
   USING (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid() AND app_users.role = 'admin'
+      WHERE app_users.id = auth.uid()::text AND app_users.role = 'admin'
     )
   );
 
@@ -556,7 +556,7 @@ CREATE POLICY "Admins can manage conflict resolutions"
   USING (
     EXISTS (
       SELECT 1 FROM app_users
-      WHERE app_users.id = auth.uid() AND app_users.role = 'admin'
+      WHERE app_users.id = auth.uid()::text AND app_users.role = 'admin'
     )
   );
 

--- a/supabase/migrations/20251024080033_add_missing_advanced_tables.sql
+++ b/supabase/migrations/20251024080033_add_missing_advanced_tables.sql
@@ -81,7 +81,7 @@ CREATE TABLE IF NOT EXISTS lab_orders (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
   visit_id text REFERENCES visits(id) ON DELETE SET NULL,
-  ordered_by uuid REFERENCES app_users(id),
+  ordered_by text REFERENCES app_users(id),
   test_name text NOT NULL,
   test_code text,
   priority text NOT NULL DEFAULT 'routine' CHECK (priority IN ('routine', 'urgent', 'stat')),
@@ -104,7 +104,7 @@ CREATE TABLE IF NOT EXISTS lab_results (
   reference_range text,
   interpretation text NOT NULL DEFAULT 'normal' CHECK (interpretation IN ('normal', 'abnormal', 'critical')),
   result_date timestamptz NOT NULL DEFAULT now(),
-  reviewed_by uuid REFERENCES app_users(id),
+  reviewed_by text REFERENCES app_users(id),
   reviewed_at timestamptz,
   notes text,
   created_at timestamptz NOT NULL DEFAULT now(),
@@ -121,7 +121,7 @@ CREATE INDEX IF NOT EXISTS idx_lab_results_order ON lab_results(order_id);
 CREATE TABLE IF NOT EXISTS appointments (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
-  provider_id uuid REFERENCES app_users(id),
+  provider_id text REFERENCES app_users(id),
   appointment_type text NOT NULL,
   scheduled_at timestamptz NOT NULL,
   duration_minutes integer NOT NULL DEFAULT 30,
@@ -130,7 +130,7 @@ CREATE TABLE IF NOT EXISTS appointments (
   notes text,
   reminder_sent boolean NOT NULL DEFAULT false,
   reminder_sent_at timestamptz,
-  created_by uuid REFERENCES app_users(id) NOT NULL,
+  created_by text REFERENCES app_users(id) NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );
@@ -239,7 +239,7 @@ CREATE TABLE IF NOT EXISTS patient_allergies (
   is_active boolean NOT NULL DEFAULT true,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now(),
-  created_by uuid REFERENCES app_users(id),
+  created_by text REFERENCES app_users(id),
   _dirty integer DEFAULT 0,
   _synced_at timestamptz
 );

--- a/supabase/migrations/20251024120000_add_missing_gamification_tables.sql
+++ b/supabase/migrations/20251024120000_add_missing_gamification_tables.sql
@@ -296,6 +296,7 @@ CREATE POLICY "Users can view own wallet"
   TO authenticated
   USING (volunteer_id = auth.uid()::text OR auth.uid() IN (SELECT id FROM app_users WHERE role = 'admin'));
 
+DROP POLICY IF EXISTS "Users can update own wallet" ON gamification_wallets;
 CREATE POLICY "Users can update own wallet"
   ON gamification_wallets FOR UPDATE
   TO authenticated

--- a/supabase/migrations/20251024120000_add_missing_gamification_tables.sql
+++ b/supabase/migrations/20251024120000_add_missing_gamification_tables.sql
@@ -278,7 +278,7 @@ ALTER TABLE message_templates ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "Users can view own game sessions"
   ON game_sessions FOR SELECT
   TO authenticated
-  USING (volunteer_id = auth.uid()::text OR auth.uid() IN (SELECT id FROM app_users WHERE role = 'admin'));
+  USING (volunteer_id = auth.uid()::text OR auth.uid()::text IN (SELECT id FROM app_users WHERE role = 'admin'));
 
 CREATE POLICY "Users can create own game sessions"
   ON game_sessions FOR INSERT
@@ -294,7 +294,7 @@ CREATE POLICY "Users can update own game sessions"
 CREATE POLICY "Users can view own wallet"
   ON gamification_wallets FOR SELECT
   TO authenticated
-  USING (volunteer_id = auth.uid()::text OR auth.uid() IN (SELECT id FROM app_users WHERE role = 'admin'));
+  USING (volunteer_id = auth.uid()::text OR auth.uid()::text IN (SELECT id FROM app_users WHERE role = 'admin'));
 
 DROP POLICY IF EXISTS "Users can update own wallet" ON gamification_wallets;
 CREATE POLICY "Users can update own wallet"
@@ -316,8 +316,8 @@ CREATE POLICY "Authenticated users can view vitals ranges"
 CREATE POLICY "Admins can manage vitals ranges"
   ON vitals_ranges FOR ALL
   TO authenticated
-  USING (auth.uid() IN (SELECT id FROM app_users WHERE role = 'admin'))
-  WITH CHECK (auth.uid() IN (SELECT id FROM app_users WHERE role = 'admin'));
+  USING (auth.uid()::text IN (SELECT id FROM app_users WHERE role = 'admin'))
+  WITH CHECK (auth.uid()::text IN (SELECT id FROM app_users WHERE role = 'admin'));
 
 -- RLS Policies for quiz_questions (read-only for users)
 CREATE POLICY "Authenticated users can view quiz questions"
@@ -328,8 +328,8 @@ CREATE POLICY "Authenticated users can view quiz questions"
 CREATE POLICY "Admins can manage quiz questions"
   ON quiz_questions FOR ALL
   TO authenticated
-  USING (auth.uid() IN (SELECT id FROM app_users WHERE role = 'admin'))
-  WITH CHECK (auth.uid() IN (SELECT id FROM app_users WHERE role = 'admin'));
+  USING (auth.uid()::text IN (SELECT id FROM app_users WHERE role = 'admin'))
+  WITH CHECK (auth.uid()::text IN (SELECT id FROM app_users WHERE role = 'admin'));
 
 -- RLS Policies for triage_samples
 CREATE POLICY "Authenticated users can view triage samples"
@@ -340,7 +340,7 @@ CREATE POLICY "Authenticated users can view triage samples"
 CREATE POLICY "Staff can create triage samples"
   ON triage_samples FOR INSERT
   TO authenticated
-  WITH CHECK (auth.uid() IN (SELECT id FROM app_users WHERE role IN ('nurse', 'doctor', 'admin')));
+  WITH CHECK (auth.uid()::text IN (SELECT id FROM app_users WHERE role IN ('nurse', 'doctor', 'admin')));
 
 -- RLS Policies for triage_records
 CREATE POLICY "Authenticated users can view triage records"
@@ -351,44 +351,44 @@ CREATE POLICY "Authenticated users can view triage records"
 CREATE POLICY "Staff can create triage records"
   ON triage_records FOR INSERT
   TO authenticated
-  WITH CHECK (auth.uid() IN (SELECT id FROM app_users WHERE role IN ('chw', 'nurse', 'doctor', 'admin')));
+  WITH CHECK (auth.uid()::text IN (SELECT id FROM app_users WHERE role IN ('chw', 'nurse', 'doctor', 'admin')));
 
 CREATE POLICY "Staff can update triage records"
   ON triage_records FOR UPDATE
   TO authenticated
-  USING (auth.uid() IN (SELECT id FROM app_users WHERE role IN ('chw', 'nurse', 'doctor', 'admin')));
+  USING (auth.uid()::text IN (SELECT id FROM app_users WHERE role IN ('chw', 'nurse', 'doctor', 'admin')));
 
 -- RLS Policies for inventory_discrepancies
 CREATE POLICY "Staff can view inventory discrepancies"
   ON inventory_discrepancies FOR SELECT
   TO authenticated
-  USING (auth.uid() IN (SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')));
+  USING (auth.uid()::text IN (SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')));
 
 CREATE POLICY "Staff can create inventory discrepancies"
   ON inventory_discrepancies FOR INSERT
   TO authenticated
-  WITH CHECK (auth.uid() IN (SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')));
+  WITH CHECK (auth.uid()::text IN (SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')));
 
 CREATE POLICY "Staff can update inventory discrepancies"
   ON inventory_discrepancies FOR UPDATE
   TO authenticated
-  USING (auth.uid() IN (SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')));
+  USING (auth.uid()::text IN (SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')));
 
 -- RLS Policies for stock_batches
 CREATE POLICY "Staff can view stock batches"
   ON stock_batches FOR SELECT
   TO authenticated
-  USING (auth.uid() IN (SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')));
+  USING (auth.uid()::text IN (SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')));
 
 CREATE POLICY "Staff can create stock batches"
   ON stock_batches FOR INSERT
   TO authenticated
-  WITH CHECK (auth.uid() IN (SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')));
+  WITH CHECK (auth.uid()::text IN (SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')));
 
 CREATE POLICY "Staff can update stock batches"
   ON stock_batches FOR UPDATE
   TO authenticated
-  USING (auth.uid() IN (SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')));
+  USING (auth.uid()::text IN (SELECT id FROM app_users WHERE role IN ('pharmacist', 'admin')));
 
 -- RLS Policies for care_tasks
 CREATE POLICY "Staff can view care tasks"
@@ -399,12 +399,12 @@ CREATE POLICY "Staff can view care tasks"
 CREATE POLICY "Staff can create care tasks"
   ON care_tasks FOR INSERT
   TO authenticated
-  WITH CHECK (auth.uid() IN (SELECT id FROM app_users WHERE role IN ('chw', 'nurse', 'doctor', 'pharmacist', 'admin')));
+  WITH CHECK (auth.uid()::text IN (SELECT id FROM app_users WHERE role IN ('chw', 'nurse', 'doctor', 'pharmacist', 'admin')));
 
 CREATE POLICY "Staff can update care tasks"
   ON care_tasks FOR UPDATE
   TO authenticated
-  USING (auth.uid() IN (SELECT id FROM app_users WHERE role IN ('chw', 'nurse', 'doctor', 'pharmacist', 'admin')));
+  USING (auth.uid()::text IN (SELECT id FROM app_users WHERE role IN ('chw', 'nurse', 'doctor', 'pharmacist', 'admin')));
 
 -- RLS Policies for patient_merges
 CREATE POLICY "Staff can view patient merges"
@@ -415,7 +415,7 @@ CREATE POLICY "Staff can view patient merges"
 CREATE POLICY "Authorized staff can create patient merges"
   ON patient_merges FOR INSERT
   TO authenticated
-  WITH CHECK (auth.uid() IN (SELECT id FROM app_users WHERE role IN ('nurse', 'doctor', 'admin')));
+  WITH CHECK (auth.uid()::text IN (SELECT id FROM app_users WHERE role IN ('nurse', 'doctor', 'admin')));
 
 -- RLS Policies for daily_counts
 CREATE POLICY "Authenticated users can view daily counts"
@@ -450,8 +450,8 @@ CREATE POLICY "Authenticated users can view message templates"
 CREATE POLICY "Admins can manage message templates"
   ON message_templates FOR ALL
   TO authenticated
-  USING (auth.uid() IN (SELECT id FROM app_users WHERE role = 'admin'))
-  WITH CHECK (auth.uid() IN (SELECT id FROM app_users WHERE role = 'admin'));
+  USING (auth.uid()::text IN (SELECT id FROM app_users WHERE role = 'admin'))
+  WITH CHECK (auth.uid()::text IN (SELECT id FROM app_users WHERE role = 'admin'));
 
 -- Create indexes for performance
 CREATE INDEX IF NOT EXISTS idx_game_sessions_volunteer ON game_sessions(volunteer_id);

--- a/supabase/migrations/20251024120000_add_missing_gamification_tables.sql
+++ b/supabase/migrations/20251024120000_add_missing_gamification_tables.sql
@@ -485,13 +485,23 @@ CREATE INDEX IF NOT EXISTS idx_conflict_resolutions_status ON conflict_resolutio
 CREATE INDEX IF NOT EXISTS idx_conflict_resolutions_type ON conflict_resolutions(conflict_type);
 
 -- Create updated_at triggers
+DROP TRIGGER IF EXISTS update_game_sessions_updated_at ON game_sessions;
 CREATE TRIGGER update_game_sessions_updated_at BEFORE UPDATE ON game_sessions FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+DROP TRIGGER IF EXISTS update_gamification_wallets_updated_at ON gamification_wallets;
 CREATE TRIGGER update_gamification_wallets_updated_at BEFORE UPDATE ON gamification_wallets FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+DROP TRIGGER IF EXISTS update_vitals_ranges_updated_at ON vitals_ranges;
 CREATE TRIGGER update_vitals_ranges_updated_at BEFORE UPDATE ON vitals_ranges FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+DROP TRIGGER IF EXISTS update_quiz_questions_updated_at ON quiz_questions;
 CREATE TRIGGER update_quiz_questions_updated_at BEFORE UPDATE ON quiz_questions FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+DROP TRIGGER IF EXISTS update_triage_records_updated_at ON triage_records;
 CREATE TRIGGER update_triage_records_updated_at BEFORE UPDATE ON triage_records FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+DROP TRIGGER IF EXISTS update_inventory_discrepancies_updated_at ON inventory_discrepancies;
 CREATE TRIGGER update_inventory_discrepancies_updated_at BEFORE UPDATE ON inventory_discrepancies FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+DROP TRIGGER IF EXISTS update_stock_batches_updated_at ON stock_batches;
 CREATE TRIGGER update_stock_batches_updated_at BEFORE UPDATE ON stock_batches FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+DROP TRIGGER IF EXISTS update_care_tasks_updated_at ON care_tasks;
 CREATE TRIGGER update_care_tasks_updated_at BEFORE UPDATE ON care_tasks FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+DROP TRIGGER IF EXISTS update_daily_counts_updated_at ON daily_counts;
 CREATE TRIGGER update_daily_counts_updated_at BEFORE UPDATE ON daily_counts FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+DROP TRIGGER IF EXISTS update_message_templates_updated_at ON message_templates;
 CREATE TRIGGER update_message_templates_updated_at BEFORE UPDATE ON message_templates FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/supabase/migrations/20251024121716_20251023220000_add_photo_storage.sql
+++ b/supabase/migrations/20251024121716_20251023220000_add_photo_storage.sql
@@ -30,6 +30,7 @@ VALUES (
 ON CONFLICT (id) DO NOTHING;
 
 -- Allow authenticated users to upload photos
+DROP POLICY IF EXISTS "Authenticated users can upload photos" ON storage.objects;
 CREATE POLICY "Authenticated users can upload photos"
 ON storage.objects
 FOR INSERT
@@ -40,6 +41,7 @@ WITH CHECK (
 );
 
 -- Allow public read access to photos
+DROP POLICY IF EXISTS "Public can view photos" ON storage.objects;
 CREATE POLICY "Public can view photos"
 ON storage.objects
 FOR SELECT
@@ -47,6 +49,7 @@ TO public
 USING (bucket_id = 'photos');
 
 -- Allow users to update their uploaded photos
+DROP POLICY IF EXISTS "Users can update their photos" ON storage.objects;
 CREATE POLICY "Users can update their photos"
 ON storage.objects
 FOR UPDATE
@@ -54,6 +57,7 @@ TO authenticated
 USING (bucket_id = 'photos');
 
 -- Allow users to delete photos
+DROP POLICY IF EXISTS "Users can delete photos" ON storage.objects;
 CREATE POLICY "Users can delete photos"
 ON storage.objects
 FOR DELETE

--- a/supabase/migrations/20251025000000_add_patient_allergies_preferences.sql
+++ b/supabase/migrations/20251025000000_add_patient_allergies_preferences.sql
@@ -65,7 +65,7 @@ CREATE TABLE IF NOT EXISTS patient_allergies (
   is_active boolean NOT NULL DEFAULT true,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now(),
-  created_by uuid REFERENCES users(id),
+  created_by text REFERENCES users(id),
   _dirty integer DEFAULT 0,
   _synced_at timestamptz
 );

--- a/supabase/migrations/20251025000000_add_patient_allergies_preferences.sql
+++ b/supabase/migrations/20251025000000_add_patient_allergies_preferences.sql
@@ -112,7 +112,7 @@ CREATE POLICY "Clinical staff can view patient allergies"
   USING (
     EXISTS (
       SELECT 1 FROM users
-      WHERE users.id = auth.uid()
+      WHERE users.id = auth.uid()::text
       AND users.role IN ('admin', 'doctor', 'nurse', 'pharmacist')
     )
   );
@@ -124,7 +124,7 @@ CREATE POLICY "Clinical staff can insert patient allergies"
   WITH CHECK (
     EXISTS (
       SELECT 1 FROM users
-      WHERE users.id = auth.uid()
+      WHERE users.id = auth.uid()::text
       AND users.role IN ('admin', 'doctor', 'nurse')
     )
   );
@@ -136,14 +136,14 @@ CREATE POLICY "Clinical staff can update patient allergies"
   USING (
     EXISTS (
       SELECT 1 FROM users
-      WHERE users.id = auth.uid()
+      WHERE users.id = auth.uid()::text
       AND users.role IN ('admin', 'doctor', 'nurse')
     )
   )
   WITH CHECK (
     EXISTS (
       SELECT 1 FROM users
-      WHERE users.id = auth.uid()
+      WHERE users.id = auth.uid()::text
       AND users.role IN ('admin', 'doctor', 'nurse')
     )
   );
@@ -155,7 +155,7 @@ CREATE POLICY "Admins and doctors can delete patient allergies"
   USING (
     EXISTS (
       SELECT 1 FROM users
-      WHERE users.id = auth.uid()
+      WHERE users.id = auth.uid()::text
       AND users.role IN ('admin', 'doctor')
     )
   );
@@ -169,7 +169,7 @@ CREATE POLICY "Staff can view patient preferences"
   USING (
     EXISTS (
       SELECT 1 FROM users
-      WHERE users.id = auth.uid()
+      WHERE users.id = auth.uid()::text
     )
   );
 
@@ -180,7 +180,7 @@ CREATE POLICY "Staff can insert patient preferences"
   WITH CHECK (
     EXISTS (
       SELECT 1 FROM users
-      WHERE users.id = auth.uid()
+      WHERE users.id = auth.uid()::text
     )
   );
 
@@ -191,13 +191,13 @@ CREATE POLICY "Staff can update patient preferences"
   USING (
     EXISTS (
       SELECT 1 FROM users
-      WHERE users.id = auth.uid()
+      WHERE users.id = auth.uid()::text
     )
   )
   WITH CHECK (
     EXISTS (
       SELECT 1 FROM users
-      WHERE users.id = auth.uid()
+      WHERE users.id = auth.uid()::text
     )
   );
 
@@ -208,7 +208,7 @@ CREATE POLICY "Admins can delete patient preferences"
   USING (
     EXISTS (
       SELECT 1 FROM users
-      WHERE users.id = auth.uid()
+      WHERE users.id = auth.uid()::text
       AND users.role = 'admin'
     )
   );

--- a/supabase/migrations/20251025000000_add_patient_allergies_preferences.sql
+++ b/supabase/migrations/20251025000000_add_patient_allergies_preferences.sql
@@ -55,7 +55,7 @@
 -- Create patient_allergies table
 CREATE TABLE IF NOT EXISTS patient_allergies (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+  patient_id text NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
   allergen text NOT NULL,
   allergy_type text NOT NULL CHECK (allergy_type IN ('medication', 'food', 'environmental', 'other')),
   reaction text,
@@ -73,7 +73,7 @@ CREATE TABLE IF NOT EXISTS patient_allergies (
 -- Create patient_preferences table
 CREATE TABLE IF NOT EXISTS patient_preferences (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid NOT NULL UNIQUE REFERENCES patients(id) ON DELETE CASCADE,
+  patient_id text NOT NULL UNIQUE REFERENCES patients(id) ON DELETE CASCADE,
   preferred_language text,
   communication_channel text CHECK (communication_channel IN ('sms', 'whatsapp', 'call', 'in-person')),
   best_contact_time text,

--- a/supabase/migrations/20251026000000_add_clinical_decision_support.sql
+++ b/supabase/migrations/20251026000000_add_clinical_decision_support.sql
@@ -32,7 +32,7 @@
 -- Create clinical_alerts table
 CREATE TABLE IF NOT EXISTS clinical_alerts (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+  patient_id text NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
   alert_type text NOT NULL CHECK (alert_type IN ('vital_sign', 'drug_interaction', 'high_risk', 'adherence', 'follow_up')),
   severity text NOT NULL CHECK (severity IN ('low', 'moderate', 'high', 'critical')),
   message text NOT NULL,

--- a/supabase/migrations/20251026065550_add_otp_rate_limit_tracking.sql
+++ b/supabase/migrations/20251026065550_add_otp_rate_limit_tracking.sql
@@ -76,7 +76,7 @@ CREATE POLICY "Admins can view OTP rate limit tracking"
   ON otp_rate_limit_tracking FOR SELECT
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role = 'admin'
     )
   );

--- a/supabase/migrations/20251026104953_add_portal_fields_to_patients.sql
+++ b/supabase/migrations/20251026104953_add_portal_fields_to_patients.sql
@@ -43,8 +43,16 @@ END $$;
 CREATE INDEX IF NOT EXISTS idx_patients_portal_enabled 
   ON patients(portal_enabled) WHERE portal_enabled = true;
 
-CREATE INDEX IF NOT EXISTS idx_patients_email_portal 
-  ON patients(LOWER(email)) WHERE email IS NOT NULL;
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'patients' AND column_name = 'email'
+  ) THEN
+    CREATE INDEX IF NOT EXISTS idx_patients_email_portal
+      ON patients(LOWER(email)) WHERE email IS NOT NULL;
+  END IF;
+END $$;
 
 CREATE INDEX IF NOT EXISTS idx_patients_phone_portal 
   ON patients(phone) WHERE phone IS NOT NULL;

--- a/supabase/migrations/20251026225242_20251031000001_add_patient_portal_fixed.sql
+++ b/supabase/migrations/20251026225242_20251031000001_add_patient_portal_fixed.sql
@@ -158,23 +158,16 @@ ALTER TABLE patient_consent_records ENABLE ROW LEVEL SECURITY;
 -- ============================================================================
 
 -- NOTIFICATIONS: Patients can view and update own notifications
+-- Stub policies — patient_portal_users doesn't exist yet; proper policies installed by 20251028000000
 CREATE POLICY "Patients can view own notifications"
   ON patient_notifications FOR SELECT
   TO anon, authenticated
-  USING (
-    patient_id IN (
-      SELECT patient_id FROM patient_portal_users WHERE phone_number = current_setting('request.jwt.claims', true)::json->>'phone'
-    )
-  );
+  USING (false);
 
 CREATE POLICY "Patients can update own notifications"
   ON patient_notifications FOR UPDATE
   TO anon, authenticated
-  USING (
-    patient_id IN (
-      SELECT patient_id FROM patient_portal_users WHERE phone_number = current_setting('request.jwt.claims', true)::json->>'phone'
-    )
-  );
+  USING (false);
 
 CREATE POLICY "Staff can create patient notifications"
   ON patient_notifications FOR INSERT
@@ -185,20 +178,12 @@ CREATE POLICY "Staff can create patient notifications"
 CREATE POLICY "Patients can view own messages"
   ON patient_messages FOR SELECT
   TO anon, authenticated
-  USING (
-    patient_id IN (
-      SELECT patient_id FROM patient_portal_users WHERE phone_number = current_setting('request.jwt.claims', true)::json->>'phone'
-    )
-  );
+  USING (false);
 
 CREATE POLICY "Patients can send messages"
   ON patient_messages FOR INSERT
   TO anon, authenticated
-  WITH CHECK (
-    patient_id IN (
-      SELECT patient_id FROM patient_portal_users WHERE phone_number = current_setting('request.jwt.claims', true)::json->>'phone'
-    )
-  );
+  WITH CHECK (false);
 
 CREATE POLICY "Staff can manage messages"
   ON patient_messages FOR ALL
@@ -209,20 +194,12 @@ CREATE POLICY "Staff can manage messages"
 CREATE POLICY "Patients can view own appointment requests"
   ON patient_appointment_requests FOR SELECT
   TO anon, authenticated
-  USING (
-    patient_id IN (
-      SELECT patient_id FROM patient_portal_users WHERE phone_number = current_setting('request.jwt.claims', true)::json->>'phone'
-    )
-  );
+  USING (false);
 
 CREATE POLICY "Patients can create appointment requests"
   ON patient_appointment_requests FOR INSERT
   TO anon, authenticated
-  WITH CHECK (
-    patient_id IN (
-      SELECT patient_id FROM patient_portal_users WHERE phone_number = current_setting('request.jwt.claims', true)::json->>'phone'
-    )
-  );
+  WITH CHECK (false);
 
 CREATE POLICY "Staff can manage appointment requests"
   ON patient_appointment_requests FOR ALL
@@ -233,20 +210,12 @@ CREATE POLICY "Staff can manage appointment requests"
 CREATE POLICY "Patients can view own documents"
   ON patient_documents FOR SELECT
   TO anon, authenticated
-  USING (
-    patient_id IN (
-      SELECT patient_id FROM patient_portal_users WHERE phone_number = current_setting('request.jwt.claims', true)::json->>'phone'
-    )
-  );
+  USING (false);
 
 CREATE POLICY "Patients can upload documents"
   ON patient_documents FOR INSERT
   TO anon, authenticated
-  WITH CHECK (
-    patient_id IN (
-      SELECT patient_id FROM patient_portal_users WHERE phone_number = current_setting('request.jwt.claims', true)::json->>'phone'
-    )
-  );
+  WITH CHECK (false);
 
 CREATE POLICY "Staff can manage patient documents"
   ON patient_documents FOR ALL
@@ -257,20 +226,12 @@ CREATE POLICY "Staff can manage patient documents"
 CREATE POLICY "Patients can view own consent records"
   ON patient_consent_records FOR SELECT
   TO anon, authenticated
-  USING (
-    patient_id IN (
-      SELECT patient_id FROM patient_portal_users WHERE phone_number = current_setting('request.jwt.claims', true)::json->>'phone'
-    )
-  );
+  USING (false);
 
 CREATE POLICY "Patients can create consent records"
   ON patient_consent_records FOR INSERT
   TO anon, authenticated
-  WITH CHECK (
-    patient_id IN (
-      SELECT patient_id FROM patient_portal_users WHERE phone_number = current_setting('request.jwt.claims', true)::json->>'phone'
-    )
-  );
+  WITH CHECK (false);
 
 CREATE POLICY "Staff can view consent records"
   ON patient_consent_records FOR SELECT

--- a/supabase/migrations/20251028000000_add_patient_portal.sql
+++ b/supabase/migrations/20251028000000_add_patient_portal.sql
@@ -85,7 +85,7 @@
 
 CREATE TABLE IF NOT EXISTS patient_portal_users (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid REFERENCES patients(id) ON DELETE CASCADE NOT NULL UNIQUE,
+  patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL UNIQUE,
   phone_number text NOT NULL,
   email text,
   phone_verified boolean NOT NULL DEFAULT false,
@@ -143,7 +143,7 @@ CREATE INDEX IF NOT EXISTS idx_patient_portal_sessions_active ON patient_portal_
 CREATE TABLE IF NOT EXISTS patient_portal_access_logs (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   portal_user_id uuid REFERENCES patient_portal_users(id) ON DELETE SET NULL,
-  patient_id uuid REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
+  patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
   action_type text NOT NULL,
   resource_type text NOT NULL,
   resource_id uuid,
@@ -166,7 +166,7 @@ CREATE INDEX IF NOT EXISTS idx_patient_portal_access_logs_action ON patient_port
 
 CREATE TABLE IF NOT EXISTS patient_notifications (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
+  patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
   notification_type text NOT NULL,
   title text NOT NULL,
   message text NOT NULL,
@@ -192,7 +192,7 @@ CREATE INDEX IF NOT EXISTS idx_patient_notifications_priority ON patient_notific
 
 CREATE TABLE IF NOT EXISTS patient_messages (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
+  patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
   sender_type text NOT NULL CHECK (sender_type IN ('patient', 'staff')),
   sender_id uuid NOT NULL,
   subject text,
@@ -218,7 +218,7 @@ CREATE INDEX IF NOT EXISTS idx_patient_messages_read ON patient_messages(read);
 
 CREATE TABLE IF NOT EXISTS patient_appointment_requests (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
+  patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
   appointment_type text NOT NULL,
   preferred_date_1 date NOT NULL,
   preferred_time_1 text,
@@ -229,7 +229,7 @@ CREATE TABLE IF NOT EXISTS patient_appointment_requests (
   reason text,
   notes text,
   status text NOT NULL CHECK (status IN ('pending', 'approved', 'scheduled', 'declined', 'cancelled')) DEFAULT 'pending',
-  reviewed_by uuid REFERENCES app_users(id) ON DELETE SET NULL,
+  reviewed_by text REFERENCES app_users(id) ON DELETE SET NULL,
   reviewed_at timestamptz,
   review_notes text,
   scheduled_appointment_id uuid REFERENCES appointments(id) ON DELETE SET NULL,
@@ -247,14 +247,14 @@ CREATE INDEX IF NOT EXISTS idx_patient_appointment_requests_created ON patient_a
 
 CREATE TABLE IF NOT EXISTS patient_documents (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
+  patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
   document_type text NOT NULL,
   document_name text NOT NULL,
   file_path text NOT NULL,
   file_size integer,
   mime_type text,
   uploaded_by_patient boolean NOT NULL DEFAULT true,
-  uploaded_by_user_id uuid REFERENCES app_users(id) ON DELETE SET NULL,
+  uploaded_by_user_id text REFERENCES app_users(id) ON DELETE SET NULL,
   description text,
   metadata jsonb,
   created_at timestamptz NOT NULL DEFAULT now(),
@@ -271,7 +271,7 @@ CREATE INDEX IF NOT EXISTS idx_patient_documents_created ON patient_documents(cr
 
 CREATE TABLE IF NOT EXISTS patient_consent_records (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
+  patient_id text REFERENCES patients(id) ON DELETE CASCADE NOT NULL,
   consent_type text NOT NULL,
   consent_given boolean NOT NULL,
   consent_text text NOT NULL,

--- a/supabase/migrations/20251028000000_add_patient_portal.sql
+++ b/supabase/migrations/20251028000000_add_patient_portal.sql
@@ -359,6 +359,7 @@ CREATE POLICY "Admins can view all patient sessions"
 -- ROW LEVEL SECURITY POLICIES - PATIENT NOTIFICATIONS
 -- ============================================================================
 
+DROP POLICY IF EXISTS "Patients can view own notifications" ON patient_notifications;
 CREATE POLICY "Patients can view own notifications"
   ON patient_notifications FOR SELECT
   TO authenticated
@@ -368,6 +369,7 @@ CREATE POLICY "Patients can view own notifications"
     )
   );
 
+DROP POLICY IF EXISTS "Patients can update own notifications" ON patient_notifications;
 CREATE POLICY "Patients can update own notifications"
   ON patient_notifications FOR UPDATE
   TO authenticated
@@ -382,6 +384,7 @@ CREATE POLICY "Patients can update own notifications"
     )
   );
 
+DROP POLICY IF EXISTS "Staff can create patient notifications" ON patient_notifications;
 CREATE POLICY "Staff can create patient notifications"
   ON patient_notifications FOR INSERT
   TO authenticated
@@ -395,6 +398,7 @@ CREATE POLICY "Staff can create patient notifications"
 -- ROW LEVEL SECURITY POLICIES - PATIENT MESSAGES
 -- ============================================================================
 
+DROP POLICY IF EXISTS "Patients can view own messages" ON patient_messages;
 CREATE POLICY "Patients can view own messages"
   ON patient_messages FOR SELECT
   TO authenticated
@@ -404,6 +408,7 @@ CREATE POLICY "Patients can view own messages"
     )
   );
 
+DROP POLICY IF EXISTS "Patients can send messages" ON patient_messages;
 CREATE POLICY "Patients can send messages"
   ON patient_messages FOR INSERT
   TO authenticated
@@ -453,6 +458,7 @@ CREATE POLICY "Staff can send messages to patients"
 -- ROW LEVEL SECURITY POLICIES - PATIENT APPOINTMENT REQUESTS
 -- ============================================================================
 
+DROP POLICY IF EXISTS "Patients can view own appointment requests" ON patient_appointment_requests;
 CREATE POLICY "Patients can view own appointment requests"
   ON patient_appointment_requests FOR SELECT
   TO authenticated
@@ -462,6 +468,7 @@ CREATE POLICY "Patients can view own appointment requests"
     )
   );
 
+DROP POLICY IF EXISTS "Patients can create appointment requests" ON patient_appointment_requests;
 CREATE POLICY "Patients can create appointment requests"
   ON patient_appointment_requests FOR INSERT
   TO authenticated
@@ -509,6 +516,7 @@ CREATE POLICY "Staff can review appointment requests"
 -- ROW LEVEL SECURITY POLICIES - PATIENT DOCUMENTS
 -- ============================================================================
 
+DROP POLICY IF EXISTS "Patients can view own documents" ON patient_documents;
 CREATE POLICY "Patients can view own documents"
   ON patient_documents FOR SELECT
   TO authenticated
@@ -518,6 +526,7 @@ CREATE POLICY "Patients can view own documents"
     )
   );
 
+DROP POLICY IF EXISTS "Patients can upload documents" ON patient_documents;
 CREATE POLICY "Patients can upload documents"
   ON patient_documents FOR INSERT
   TO authenticated
@@ -550,6 +559,7 @@ CREATE POLICY "Staff can upload documents for patients"
 -- ROW LEVEL SECURITY POLICIES - PATIENT CONSENT RECORDS
 -- ============================================================================
 
+DROP POLICY IF EXISTS "Patients can view own consent records" ON patient_consent_records;
 CREATE POLICY "Patients can view own consent records"
   ON patient_consent_records FOR SELECT
   TO authenticated
@@ -559,6 +569,7 @@ CREATE POLICY "Patients can view own consent records"
     )
   );
 
+DROP POLICY IF EXISTS "Patients can create consent records" ON patient_consent_records;
 CREATE POLICY "Patients can create consent records"
   ON patient_consent_records FOR INSERT
   TO authenticated
@@ -706,21 +717,25 @@ CREATE POLICY "Patients can view own preferences"
 -- UPDATED_AT TRIGGERS
 -- ============================================================================
 
+DROP TRIGGER IF EXISTS update_patient_portal_users_updated_at ON patient_portal_users;
 CREATE TRIGGER update_patient_portal_users_updated_at
   BEFORE UPDATE ON patient_portal_users
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_patient_messages_updated_at ON patient_messages;
 CREATE TRIGGER update_patient_messages_updated_at
   BEFORE UPDATE ON patient_messages
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_patient_appointment_requests_updated_at ON patient_appointment_requests;
 CREATE TRIGGER update_patient_appointment_requests_updated_at
   BEFORE UPDATE ON patient_appointment_requests
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
+DROP TRIGGER IF EXISTS update_patient_documents_updated_at ON patient_documents;
 CREATE TRIGGER update_patient_documents_updated_at
   BEFORE UPDATE ON patient_documents
   FOR EACH ROW

--- a/supabase/migrations/20251028000000_add_patient_portal.sql
+++ b/supabase/migrations/20251028000000_add_patient_portal.sql
@@ -417,7 +417,7 @@ CREATE POLICY "Patients can send messages"
       SELECT patient_id FROM patient_portal_users WHERE id = auth.uid()
     )
     AND sender_type = 'patient'
-    AND sender_id = auth.uid()
+    AND sender_id = auth.uid()::text
   );
 
 CREATE POLICY "Patients can update own messages"
@@ -451,7 +451,7 @@ CREATE POLICY "Staff can send messages to patients"
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
     AND sender_type = 'staff'
-    AND sender_id = auth.uid()
+    AND sender_id = auth.uid()::text
   );
 
 -- ============================================================================

--- a/supabase/migrations/20251028000000_add_patient_portal.sql
+++ b/supabase/migrations/20251028000000_add_patient_portal.sql
@@ -318,7 +318,7 @@ CREATE POLICY "Staff can view patient portal accounts"
   ON patient_portal_users FOR SELECT
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
   );
@@ -327,7 +327,7 @@ CREATE POLICY "Admins can manage patient portal accounts"
   ON patient_portal_users FOR ALL
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role = 'admin'
     )
   );
@@ -350,7 +350,7 @@ CREATE POLICY "Admins can view all patient sessions"
   ON patient_portal_sessions FOR SELECT
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role = 'admin'
     )
   );
@@ -389,7 +389,7 @@ CREATE POLICY "Staff can create patient notifications"
   ON patient_notifications FOR INSERT
   TO authenticated
   WITH CHECK (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw', 'pharmacist')
     )
   );
@@ -438,7 +438,7 @@ CREATE POLICY "Staff can view patient messages"
   ON patient_messages FOR SELECT
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
   );
@@ -447,7 +447,7 @@ CREATE POLICY "Staff can send messages to patients"
   ON patient_messages FOR INSERT
   TO authenticated
   WITH CHECK (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
     AND sender_type = 'staff'
@@ -498,7 +498,7 @@ CREATE POLICY "Staff can view all appointment requests"
   ON patient_appointment_requests FOR SELECT
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
   );
@@ -507,7 +507,7 @@ CREATE POLICY "Staff can review appointment requests"
   ON patient_appointment_requests FOR UPDATE
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
   );
@@ -541,7 +541,7 @@ CREATE POLICY "Staff can view patient documents"
   ON patient_documents FOR SELECT
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
   );
@@ -550,7 +550,7 @@ CREATE POLICY "Staff can upload documents for patients"
   ON patient_documents FOR INSERT
   TO authenticated
   WITH CHECK (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
   );
@@ -583,7 +583,7 @@ CREATE POLICY "Staff can view patient consent records"
   ON patient_consent_records FOR SELECT
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
   );
@@ -596,7 +596,7 @@ CREATE POLICY "Admins can view all access logs"
   ON patient_portal_access_logs FOR SELECT
   TO authenticated
   USING (
-    auth.uid() IN (
+    auth.uid()::text IN (
       SELECT id FROM app_users WHERE role = 'admin'
     )
   );

--- a/supabase/migrations/20251028121000_add_doctor_features_tables.sql
+++ b/supabase/migrations/20251028121000_add_doctor_features_tables.sql
@@ -209,7 +209,7 @@ CREATE TABLE IF NOT EXISTS protocol_library (
   medications jsonb,
   contraindications text[],
   special_considerations text,
-  references text,
+  clinical_references text,
   version text DEFAULT '1.0',
   is_active boolean DEFAULT true,
   created_by uuid NOT NULL,

--- a/supabase/migrations/20251028170413_add_multi_tenant_foundation.sql
+++ b/supabase/migrations/20251028170413_add_multi_tenant_foundation.sql
@@ -93,50 +93,60 @@ ALTER TABLE event_staff_assignments ENABLE ROW LEVEL SECURITY;
 ALTER TABLE user_org_sites ENABLE ROW LEVEL SECURITY;
 
 -- RLS Policies for organizations
+DROP POLICY IF EXISTS "Users can view their organizations" ON organizations;
 CREATE POLICY "Users can view their organizations"
   ON organizations FOR SELECT TO authenticated
   USING (id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
 
+DROP POLICY IF EXISTS "Admins can manage their organizations" ON organizations;
 CREATE POLICY "Admins can manage their organizations"
   ON organizations FOR ALL TO authenticated
   USING (id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()))
   WITH CHECK (id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
 
 -- RLS Policies for sites
+DROP POLICY IF EXISTS "Users can view sites in their organizations" ON sites;
 CREATE POLICY "Users can view sites in their organizations"
   ON sites FOR SELECT TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
 
+DROP POLICY IF EXISTS "Admins can manage sites in their organizations" ON sites;
 CREATE POLICY "Admins can manage sites in their organizations"
   ON sites FOR ALL TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()))
   WITH CHECK (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
 
 -- RLS Policies for outreach_events
+DROP POLICY IF EXISTS "Users can view events in their organizations" ON outreach_events;
 CREATE POLICY "Users can view events in their organizations"
   ON outreach_events FOR SELECT TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
 
+DROP POLICY IF EXISTS "Staff can manage events in their organizations" ON outreach_events;
 CREATE POLICY "Staff can manage events in their organizations"
   ON outreach_events FOR ALL TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()))
   WITH CHECK (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
 
 -- RLS Policies for event_staff_assignments
+DROP POLICY IF EXISTS "Users can view their event assignments" ON event_staff_assignments;
 CREATE POLICY "Users can view their event assignments"
   ON event_staff_assignments FOR SELECT TO authenticated
   USING (user_id = auth.uid() OR event_id IN (SELECT id FROM outreach_events WHERE org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid())));
 
+DROP POLICY IF EXISTS "Staff can manage event assignments in their organizations" ON event_staff_assignments;
 CREATE POLICY "Staff can manage event assignments in their organizations"
   ON event_staff_assignments FOR ALL TO authenticated
   USING (event_id IN (SELECT id FROM outreach_events WHERE org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid())))
   WITH CHECK (event_id IN (SELECT id FROM outreach_events WHERE org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid())));
 
 -- RLS Policies for user_org_sites
+DROP POLICY IF EXISTS "Users can view their own org assignments" ON user_org_sites;
 CREATE POLICY "Users can view their own org assignments"
   ON user_org_sites FOR SELECT TO authenticated
   USING (user_id = auth.uid());
 
+DROP POLICY IF EXISTS "Admins can manage user org assignments" ON user_org_sites;
 CREATE POLICY "Admins can manage user org assignments"
   ON user_org_sites FOR ALL TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()))
@@ -151,6 +161,9 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
+DROP TRIGGER IF EXISTS organizations_updated_at ON organizations;
 CREATE TRIGGER organizations_updated_at BEFORE UPDATE ON organizations FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+DROP TRIGGER IF EXISTS sites_updated_at ON sites;
 CREATE TRIGGER sites_updated_at BEFORE UPDATE ON sites FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+DROP TRIGGER IF EXISTS outreach_events_updated_at ON outreach_events;
 CREATE TRIGGER outreach_events_updated_at BEFORE UPDATE ON outreach_events FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/supabase/migrations/20251028170617_add_doctor_features_tables_part2_fixed.sql
+++ b/supabase/migrations/20251028170617_add_doctor_features_tables_part2_fixed.sql
@@ -83,22 +83,28 @@ ALTER TABLE consultation_reviews ENABLE ROW LEVEL SECURITY;
 ALTER TABLE protocol_library ENABLE ROW LEVEL SECURITY;
 
 -- RLS Policies for patient_flags
+DROP POLICY IF EXISTS "Staff can view flags in their organizations" ON patient_flags;
 CREATE POLICY "Staff can view flags in their organizations" ON patient_flags FOR SELECT TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
+DROP POLICY IF EXISTS "Staff can create flags in their organizations" ON patient_flags;
 CREATE POLICY "Staff can create flags in their organizations" ON patient_flags FOR INSERT TO authenticated
   WITH CHECK (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
+DROP POLICY IF EXISTS "Staff can update flags in their organizations" ON patient_flags;
 CREATE POLICY "Staff can update flags in their organizations" ON patient_flags FOR UPDATE TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()))
   WITH CHECK (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
 
 -- RLS Policies for referrals
+DROP POLICY IF EXISTS "Staff can view referrals in their organizations" ON referrals;
 CREATE POLICY "Staff can view referrals in their organizations" ON referrals FOR SELECT TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
+DROP POLICY IF EXISTS "Doctors can manage referrals in their organizations" ON referrals;
 CREATE POLICY "Doctors can manage referrals in their organizations" ON referrals FOR ALL TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()))
   WITH CHECK (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
 
 -- RLS Policies for follow_up_schedules
+DROP POLICY IF EXISTS "Staff can view follow-ups in their organizations" ON follow_up_schedules;
 CREATE POLICY "Staff can view follow-ups in their organizations" ON follow_up_schedules FOR SELECT TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
 CREATE POLICY "Clinical staff can manage follow-ups" ON follow_up_schedules FOR ALL TO authenticated
@@ -122,6 +128,7 @@ CREATE POLICY "Pharmacists can manage site formulary" ON site_formulary FOR ALL 
 -- RLS Policies for doctor_analytics
 CREATE POLICY "Staff can view doctor analytics" ON doctor_analytics FOR SELECT TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()) OR doctor_id = auth.uid());
+DROP POLICY IF EXISTS "System can manage doctor analytics" ON doctor_analytics;
 CREATE POLICY "System can manage doctor analytics" ON doctor_analytics FOR ALL TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()))
   WITH CHECK (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
@@ -129,6 +136,7 @@ CREATE POLICY "System can manage doctor analytics" ON doctor_analytics FOR ALL T
 -- RLS Policies for consultation_reviews
 CREATE POLICY "Staff can view consultation reviews" ON consultation_reviews FOR SELECT TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()) OR reviewed_doctor_id = auth.uid() OR reviewing_doctor_id = auth.uid());
+DROP POLICY IF EXISTS "Supervising doctors can manage reviews" ON consultation_reviews;
 CREATE POLICY "Supervising doctors can manage reviews" ON consultation_reviews FOR ALL TO authenticated
   USING (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()))
   WITH CHECK (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
@@ -141,9 +149,15 @@ CREATE POLICY "Doctors can manage protocols" ON protocol_library FOR ALL TO auth
   WITH CHECK (org_id IN (SELECT org_id FROM user_org_sites WHERE user_id = auth.uid()));
 
 -- Triggers
+DROP TRIGGER IF EXISTS referrals_updated_at ON referrals;
 CREATE TRIGGER referrals_updated_at BEFORE UPDATE ON referrals FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+DROP TRIGGER IF EXISTS follow_up_schedules_updated_at ON follow_up_schedules;
 CREATE TRIGGER follow_up_schedules_updated_at BEFORE UPDATE ON follow_up_schedules FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+DROP TRIGGER IF EXISTS prescription_templates_updated_at ON prescription_templates;
 CREATE TRIGGER prescription_templates_updated_at BEFORE UPDATE ON prescription_templates FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+DROP TRIGGER IF EXISTS site_formulary_updated_at ON site_formulary;
 CREATE TRIGGER site_formulary_updated_at BEFORE UPDATE ON site_formulary FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+DROP TRIGGER IF EXISTS doctor_analytics_updated_at ON doctor_analytics;
 CREATE TRIGGER doctor_analytics_updated_at BEFORE UPDATE ON doctor_analytics FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+DROP TRIGGER IF EXISTS protocol_library_updated_at ON protocol_library;
 CREATE TRIGGER protocol_library_updated_at BEFORE UPDATE ON protocol_library FOR EACH ROW EXECUTE FUNCTION update_updated_at();

--- a/supabase/migrations/20251029000000_add_patient_email_auth_fields.sql
+++ b/supabase/migrations/20251029000000_add_patient_email_auth_fields.sql
@@ -102,14 +102,7 @@ CREATE POLICY "Patients can verify own contact"
   FOR UPDATE
   TO authenticated
   USING (auth.uid()::text = auth_uid)
-  WITH CHECK (
-    auth.uid()::text = auth_uid AND
-    -- Only allow updating contact_verified field
-    (
-      (OLD.email = NEW.email OR (OLD.email IS NULL AND NEW.email IS NULL)) AND
-      (OLD.phone = NEW.phone OR (OLD.phone IS NULL AND NEW.phone IS NULL))
-    )
-  );
+  WITH CHECK (auth.uid()::text = auth_uid);
 
 -- Step 7: Add comment explaining the table structure
 COMMENT ON COLUMN patients.email IS 'Patient email address for portal login (unique, case-insensitive)';

--- a/supabase/migrations/20251030000000_add_patient_portal_features.sql
+++ b/supabase/migrations/20251030000000_add_patient_portal_features.sql
@@ -168,6 +168,7 @@ ALTER TABLE patient_portal_preferences ENABLE ROW LEVEL SECURITY;
 
 -- RLS Policies for patient_secure_messages
 
+DROP POLICY IF EXISTS "Patients can view own messages" ON patient_secure_messages;
 CREATE POLICY "Patients can view own messages"
   ON patient_secure_messages FOR SELECT
   TO authenticated
@@ -178,6 +179,7 @@ CREATE POLICY "Patients can view own messages"
     )
   );
 
+DROP POLICY IF EXISTS "Patients can send messages" ON patient_secure_messages;
 CREATE POLICY "Patients can send messages"
   ON patient_secure_messages FOR INSERT
   TO authenticated
@@ -200,6 +202,7 @@ CREATE POLICY "Staff can send messages"
 
 -- RLS Policies for patient_lab_results
 
+DROP POLICY IF EXISTS "Patients can view own lab results" ON patient_lab_results;
 CREATE POLICY "Patients can view own lab results"
   ON patient_lab_results FOR SELECT
   TO authenticated
@@ -223,6 +226,7 @@ CREATE POLICY "Staff can manage lab results"
 
 -- RLS Policies for patient_medical_conditions
 
+DROP POLICY IF EXISTS "Patients can view own conditions" ON patient_medical_conditions;
 CREATE POLICY "Patients can view own conditions"
   ON patient_medical_conditions FOR SELECT
   TO authenticated
@@ -250,6 +254,7 @@ CREATE POLICY "Staff can view all conditions"
 
 -- RLS Policies for patient_documents
 
+DROP POLICY IF EXISTS "Patients can view own documents" ON patient_documents;
 CREATE POLICY "Patients can view own documents"
   ON patient_documents FOR SELECT
   TO authenticated
@@ -260,6 +265,7 @@ CREATE POLICY "Patients can view own documents"
     )
   );
 
+DROP POLICY IF EXISTS "Patients can upload documents" ON patient_documents;
 CREATE POLICY "Patients can upload documents"
   ON patient_documents FOR INSERT
   TO authenticated

--- a/supabase/migrations/20251030000000_add_patient_portal_features.sql
+++ b/supabase/migrations/20251030000000_add_patient_portal_features.sql
@@ -120,7 +120,7 @@ CREATE TABLE IF NOT EXISTS patient_documents (
   created_at timestamptz DEFAULT now()
 );
 
-CREATE INDEX IF NOT EXISTS idx_documents_patient ON patient_documents(patient_id, upload_date DESC);
+CREATE INDEX IF NOT EXISTS idx_documents_patient ON patient_documents(patient_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_documents_type ON patient_documents(patient_id, document_type);
 
 -- Create referrals table

--- a/supabase/migrations/20251030000000_add_patient_portal_features.sql
+++ b/supabase/migrations/20251030000000_add_patient_portal_features.sql
@@ -53,7 +53,7 @@
 CREATE TABLE IF NOT EXISTS patient_secure_messages (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   patient_id uuid NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
-  staff_id uuid REFERENCES users(id) ON DELETE SET NULL,
+  staff_id text REFERENCES users(id) ON DELETE SET NULL,
   subject text NOT NULL,
   body text NOT NULL,
   from_patient boolean NOT NULL DEFAULT true,
@@ -81,7 +81,7 @@ CREATE TABLE IF NOT EXISTS patient_lab_results (
   result_date timestamptz,
   notes text,
   abnormal boolean DEFAULT false,
-  ordered_by uuid REFERENCES users(id) ON DELETE SET NULL,
+  ordered_by text REFERENCES users(id) ON DELETE SET NULL,
   created_at timestamptz DEFAULT now(),
   updated_at timestamptz DEFAULT now()
 );
@@ -116,7 +116,7 @@ CREATE TABLE IF NOT EXISTS patient_documents (
   description text,
   storage_path text NOT NULL,
   upload_date timestamptz DEFAULT now(),
-  uploaded_by uuid REFERENCES users(id) ON DELETE SET NULL,
+  uploaded_by text REFERENCES users(id) ON DELETE SET NULL,
   created_at timestamptz DEFAULT now()
 );
 
@@ -136,7 +136,7 @@ CREATE TABLE IF NOT EXISTS patient_referrals (
   status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'scheduled', 'completed', 'cancelled')),
   priority text NOT NULL DEFAULT 'routine' CHECK (priority IN ('routine', 'urgent', 'emergency')),
   notes text,
-  created_by uuid REFERENCES users(id) ON DELETE SET NULL,
+  created_by text REFERENCES users(id) ON DELETE SET NULL,
   created_at timestamptz DEFAULT now(),
   updated_at timestamptz DEFAULT now()
 );

--- a/supabase/migrations/20251030000000_add_patient_portal_features.sql
+++ b/supabase/migrations/20251030000000_add_patient_portal_features.sql
@@ -52,7 +52,7 @@
 -- Create secure messaging table
 CREATE TABLE IF NOT EXISTS patient_secure_messages (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+  patient_id text NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
   staff_id text REFERENCES users(id) ON DELETE SET NULL,
   subject text NOT NULL,
   body text NOT NULL,
@@ -70,7 +70,7 @@ CREATE INDEX IF NOT EXISTS idx_secure_messages_unread ON patient_secure_messages
 -- Create lab results table
 CREATE TABLE IF NOT EXISTS patient_lab_results (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+  patient_id text NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
   test_name text NOT NULL,
   test_type text NOT NULL,
   result_value text,
@@ -93,7 +93,7 @@ CREATE INDEX IF NOT EXISTS idx_lab_results_abnormal ON patient_lab_results(patie
 -- Create medical conditions table
 CREATE TABLE IF NOT EXISTS patient_medical_conditions (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+  patient_id text NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
   condition_name text NOT NULL,
   diagnosed_date date,
   status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'resolved', 'managed')),
@@ -108,7 +108,7 @@ CREATE INDEX IF NOT EXISTS idx_medical_conditions_status ON patient_medical_cond
 -- Create documents table
 CREATE TABLE IF NOT EXISTS patient_documents (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+  patient_id text NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
   file_name text NOT NULL,
   file_type text NOT NULL,
   file_size integer NOT NULL,
@@ -126,7 +126,7 @@ CREATE INDEX IF NOT EXISTS idx_documents_type ON patient_documents(patient_id, d
 -- Create referrals table
 CREATE TABLE IF NOT EXISTS patient_referrals (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  patient_id uuid NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
+  patient_id text NOT NULL REFERENCES patients(id) ON DELETE CASCADE,
   referring_provider text NOT NULL,
   specialist_name text,
   specialty text NOT NULL,

--- a/supabase/migrations/20251031000000_fix_patient_session_rls.sql
+++ b/supabase/migrations/20251031000000_fix_patient_session_rls.sql
@@ -45,7 +45,7 @@ CREATE POLICY "Staff can view all patient sessions"
   USING (
     EXISTS (
       SELECT 1 FROM users
-      WHERE id = auth.uid()
+      WHERE id = auth.uid()::text
       AND role IN ('admin', 'doctor', 'nurse')
     )
   );
@@ -57,14 +57,14 @@ CREATE POLICY "Staff can manage patient sessions"
   USING (
     EXISTS (
       SELECT 1 FROM users
-      WHERE id = auth.uid()
+      WHERE id = auth.uid()::text
       AND role IN ('admin', 'doctor', 'nurse')
     )
   )
   WITH CHECK (
     EXISTS (
       SELECT 1 FROM users
-      WHERE id = auth.uid()
+      WHERE id = auth.uid()::text
       AND role IN ('admin', 'doctor', 'nurse')
     )
   );

--- a/supabase/migrations/20251031000001_add_patient_portal_fixed.sql
+++ b/supabase/migrations/20251031000001_add_patient_portal_fixed.sql
@@ -158,6 +158,7 @@ ALTER TABLE patient_consent_records ENABLE ROW LEVEL SECURITY;
 -- ============================================================================
 
 -- NOTIFICATIONS: Patients can view and update own notifications
+DROP POLICY IF EXISTS "Patients can view own notifications" ON patient_notifications;
 CREATE POLICY "Patients can view own notifications"
   ON patient_notifications FOR SELECT
   TO anon, authenticated
@@ -167,6 +168,7 @@ CREATE POLICY "Patients can view own notifications"
     )
   );
 
+DROP POLICY IF EXISTS "Patients can update own notifications" ON patient_notifications;
 CREATE POLICY "Patients can update own notifications"
   ON patient_notifications FOR UPDATE
   TO anon, authenticated
@@ -176,12 +178,14 @@ CREATE POLICY "Patients can update own notifications"
     )
   );
 
+DROP POLICY IF EXISTS "Staff can create patient notifications" ON patient_notifications;
 CREATE POLICY "Staff can create patient notifications"
   ON patient_notifications FOR INSERT
   TO authenticated
   WITH CHECK (true);
 
 -- MESSAGES: Patients can view and send messages
+DROP POLICY IF EXISTS "Patients can view own messages" ON patient_messages;
 CREATE POLICY "Patients can view own messages"
   ON patient_messages FOR SELECT
   TO anon, authenticated
@@ -191,6 +195,7 @@ CREATE POLICY "Patients can view own messages"
     )
   );
 
+DROP POLICY IF EXISTS "Patients can send messages" ON patient_messages;
 CREATE POLICY "Patients can send messages"
   ON patient_messages FOR INSERT
   TO anon, authenticated
@@ -200,12 +205,14 @@ CREATE POLICY "Patients can send messages"
     )
   );
 
+DROP POLICY IF EXISTS "Staff can manage messages" ON patient_messages;
 CREATE POLICY "Staff can manage messages"
   ON patient_messages FOR ALL
   TO authenticated
   USING (true);
 
 -- APPOINTMENT REQUESTS: Patients can create and view own requests
+DROP POLICY IF EXISTS "Patients can view own appointment requests" ON patient_appointment_requests;
 CREATE POLICY "Patients can view own appointment requests"
   ON patient_appointment_requests FOR SELECT
   TO anon, authenticated
@@ -215,6 +222,7 @@ CREATE POLICY "Patients can view own appointment requests"
     )
   );
 
+DROP POLICY IF EXISTS "Patients can create appointment requests" ON patient_appointment_requests;
 CREATE POLICY "Patients can create appointment requests"
   ON patient_appointment_requests FOR INSERT
   TO anon, authenticated
@@ -224,12 +232,14 @@ CREATE POLICY "Patients can create appointment requests"
     )
   );
 
+DROP POLICY IF EXISTS "Staff can manage appointment requests" ON patient_appointment_requests;
 CREATE POLICY "Staff can manage appointment requests"
   ON patient_appointment_requests FOR ALL
   TO authenticated
   USING (true);
 
 -- DOCUMENTS: Patients can upload and view own documents
+DROP POLICY IF EXISTS "Patients can view own documents" ON patient_documents;
 CREATE POLICY "Patients can view own documents"
   ON patient_documents FOR SELECT
   TO anon, authenticated
@@ -239,6 +249,7 @@ CREATE POLICY "Patients can view own documents"
     )
   );
 
+DROP POLICY IF EXISTS "Patients can upload documents" ON patient_documents;
 CREATE POLICY "Patients can upload documents"
   ON patient_documents FOR INSERT
   TO anon, authenticated
@@ -248,12 +259,14 @@ CREATE POLICY "Patients can upload documents"
     )
   );
 
+DROP POLICY IF EXISTS "Staff can manage patient documents" ON patient_documents;
 CREATE POLICY "Staff can manage patient documents"
   ON patient_documents FOR ALL
   TO authenticated
   USING (true);
 
 -- CONSENT RECORDS: Patients can view and create own consent
+DROP POLICY IF EXISTS "Patients can view own consent records" ON patient_consent_records;
 CREATE POLICY "Patients can view own consent records"
   ON patient_consent_records FOR SELECT
   TO anon, authenticated
@@ -263,6 +276,7 @@ CREATE POLICY "Patients can view own consent records"
     )
   );
 
+DROP POLICY IF EXISTS "Patients can create consent records" ON patient_consent_records;
 CREATE POLICY "Patients can create consent records"
   ON patient_consent_records FOR INSERT
   TO anon, authenticated
@@ -272,6 +286,7 @@ CREATE POLICY "Patients can create consent records"
     )
   );
 
+DROP POLICY IF EXISTS "Staff can view consent records" ON patient_consent_records;
 CREATE POLICY "Staff can view consent records"
   ON patient_consent_records FOR SELECT
   TO authenticated

--- a/supabase/migrations/20251214162156_add_palaver_room_messaging.sql
+++ b/supabase/migrations/20251214162156_add_palaver_room_messaging.sql
@@ -94,13 +94,13 @@ CREATE POLICY "Users can view messages they sent or received"
   ON palaver_messages FOR SELECT
   TO authenticated
   USING (
-    sender_id = auth.uid()::text OR recipient_id = auth.uid()::text
+    sender_id = auth.uid() OR recipient_id = auth.uid()::text
   );
 
 CREATE POLICY "Users can insert messages they send"
   ON palaver_messages FOR INSERT
   TO authenticated
-  WITH CHECK (sender_id = auth.uid()::text);
+  WITH CHECK (sender_id = auth.uid());
 
 CREATE POLICY "Recipients can update read status"
   ON palaver_messages FOR UPDATE
@@ -117,18 +117,18 @@ CREATE POLICY "All authenticated users can view active broadcasts"
 CREATE POLICY "Doctors and admins can create broadcasts"
   ON palaver_broadcasts FOR INSERT
   TO authenticated
-  WITH CHECK (sender_id = auth.uid()::text);
+  WITH CHECK (sender_id = auth.uid());
 
 -- RLS Policies for palaver_broadcast_reads
 CREATE POLICY "Users can view their own broadcast reads"
   ON palaver_broadcast_reads FOR SELECT
   TO authenticated
-  USING (user_id = auth.uid()::text);
+  USING (user_id = auth.uid());
 
 CREATE POLICY "Users can mark broadcasts as read"
   ON palaver_broadcast_reads FOR INSERT
   TO authenticated
-  WITH CHECK (user_id = auth.uid()::text);
+  WITH CHECK (user_id = auth.uid());
 
 -- Create indexes for performance
 CREATE INDEX IF NOT EXISTS idx_palaver_messages_recipient ON palaver_messages(recipient_id, is_read, created_at DESC);

--- a/supabase/migrations/20251214162156_add_palaver_room_messaging.sql
+++ b/supabase/migrations/20251214162156_add_palaver_room_messaging.sql
@@ -94,13 +94,13 @@ CREATE POLICY "Users can view messages they sent or received"
   ON palaver_messages FOR SELECT
   TO authenticated
   USING (
-    sender_id = auth.uid() OR recipient_id = auth.uid()::text
+    sender_id = auth.uid()::text OR recipient_id = auth.uid()::text
   );
 
 CREATE POLICY "Users can insert messages they send"
   ON palaver_messages FOR INSERT
   TO authenticated
-  WITH CHECK (sender_id = auth.uid());
+  WITH CHECK (sender_id = auth.uid()::text);
 
 CREATE POLICY "Recipients can update read status"
   ON palaver_messages FOR UPDATE
@@ -117,18 +117,18 @@ CREATE POLICY "All authenticated users can view active broadcasts"
 CREATE POLICY "Doctors and admins can create broadcasts"
   ON palaver_broadcasts FOR INSERT
   TO authenticated
-  WITH CHECK (sender_id = auth.uid());
+  WITH CHECK (sender_id = auth.uid()::text);
 
 -- RLS Policies for palaver_broadcast_reads
 CREATE POLICY "Users can view their own broadcast reads"
   ON palaver_broadcast_reads FOR SELECT
   TO authenticated
-  USING (user_id = auth.uid());
+  USING (user_id = auth.uid()::text);
 
 CREATE POLICY "Users can mark broadcasts as read"
   ON palaver_broadcast_reads FOR INSERT
   TO authenticated
-  WITH CHECK (user_id = auth.uid());
+  WITH CHECK (user_id = auth.uid()::text);
 
 -- Create indexes for performance
 CREATE INDEX IF NOT EXISTS idx_palaver_messages_recipient ON palaver_messages(recipient_id, is_read, created_at DESC);

--- a/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
+++ b/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS conflict_resolutions (
 -- Conflict Audit Logs Table (append-only for compliance)
 CREATE TABLE IF NOT EXISTS conflict_audit_logs (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  conflict_id uuid NOT NULL REFERENCES conflict_resolutions(id) ON DELETE CASCADE,
+  conflict_id text NOT NULL REFERENCES conflict_resolutions(id) ON DELETE CASCADE,
   action text NOT NULL CHECK (action IN ('created', 'viewed', 'resolved', 'approved', 'rejected', 'appealed', 'auto_resolved')),
   actor_id uuid REFERENCES auth.users(id),
   actor_role text,

--- a/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
+++ b/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
@@ -106,6 +106,11 @@ CREATE TABLE IF NOT EXISTS auto_resolution_rules (
   updated_at timestamptz NOT NULL DEFAULT now()
 );
 
+-- Add columns to conflict_resolutions if created by earlier migration without them
+ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS entity_type text;
+ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS entity_id text;
+ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS priority integer NOT NULL DEFAULT 5;
+
 -- Indexes for performance
 CREATE INDEX IF NOT EXISTS idx_conflict_resolutions_status ON conflict_resolutions(status);
 CREATE INDEX IF NOT EXISTS idx_conflict_resolutions_entity ON conflict_resolutions(entity_type, entity_id);

--- a/supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql
+++ b/supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql
@@ -35,7 +35,7 @@
 -- Create conflict_change_deltas table for granular field tracking
 CREATE TABLE IF NOT EXISTS conflict_change_deltas (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  conflict_id uuid NOT NULL REFERENCES conflict_resolutions(id) ON DELETE CASCADE,
+  conflict_id text NOT NULL REFERENCES conflict_resolutions(id) ON DELETE CASCADE,
   field_name text NOT NULL,
   old_value jsonb,
   new_value jsonb,

--- a/supabase/migrations/20260417000000_add_staff_roles_and_rbac.sql
+++ b/supabase/migrations/20260417000000_add_staff_roles_and_rbac.sql
@@ -1,0 +1,104 @@
+/*
+  # Staff Roles & Portal RBAC
+
+  Adds the `staff_roles` table and `is_staff()` helper function so the
+  patient-portal route protection can distinguish staff from patients.
+
+  Applies additive RLS policies on the core tables so authenticated staff
+  users can read all patient data and insert vitals / medications / visits —
+  without touching or breaking any existing RLS policies.
+
+  New objects
+  ───────────
+  • public.staff_roles          – one row per staff auth.users account
+  • public.is_staff()           – returns true when the calling user is staff
+  • RLS policies on patients, vitals, consultations, dispenses, visits
+*/
+
+-- ─── staff_roles ──────────────────────────────────────────────────────────────
+create table if not exists public.staff_roles (
+  id              uuid primary key default gen_random_uuid(),
+  auth_user_id    uuid not null references auth.users(id) on delete cascade,
+  role            text not null default 'staff',
+  created_at      timestamptz not null default now(),
+
+  constraint staff_roles_role_check
+    check (role in ('staff', 'admin', 'doctor', 'nurse', 'pharmacist', 'volunteer'))
+);
+
+create unique index if not exists staff_roles_auth_user_id_idx
+  on public.staff_roles (auth_user_id);
+
+alter table public.staff_roles enable row level security;
+
+-- Each staff member can read their own role row
+create policy "Staff reads own role"
+  on public.staff_roles for select
+  using (auth.uid() = auth_user_id);
+
+-- ─── is_staff() helper ────────────────────────────────────────────────────────
+create or replace function public.is_staff()
+returns boolean
+language sql stable security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.staff_roles
+    where auth_user_id = auth.uid()
+  );
+$$;
+
+-- ─── patients – staff read-all policy ────────────────────────────────────────
+drop policy if exists "Staff can read all patients" on public.patients;
+create policy "Staff can read all patients"
+  on public.patients for select
+  using (public.is_staff());
+
+-- ─── vitals – staff read & insert ────────────────────────────────────────────
+drop policy if exists "Staff can read all vitals"  on public.vitals;
+drop policy if exists "Staff can insert vitals"    on public.vitals;
+
+create policy "Staff can read all vitals"
+  on public.vitals for select
+  using (public.is_staff());
+
+create policy "Staff can insert vitals"
+  on public.vitals for insert
+  with check (public.is_staff());
+
+-- ─── consultations – staff read & insert ─────────────────────────────────────
+drop policy if exists "Staff can read all consultations" on public.consultations;
+drop policy if exists "Staff can insert consultations"   on public.consultations;
+
+create policy "Staff can read all consultations"
+  on public.consultations for select
+  using (public.is_staff());
+
+create policy "Staff can insert consultations"
+  on public.consultations for insert
+  with check (public.is_staff());
+
+-- ─── dispenses – staff read & insert ─────────────────────────────────────────
+drop policy if exists "Staff can read all dispenses" on public.dispenses;
+drop policy if exists "Staff can insert dispenses"   on public.dispenses;
+
+create policy "Staff can read all dispenses"
+  on public.dispenses for select
+  using (public.is_staff());
+
+create policy "Staff can insert dispenses"
+  on public.dispenses for insert
+  with check (public.is_staff());
+
+-- ─── visits – staff read & insert ────────────────────────────────────────────
+drop policy if exists "Staff can read all visits" on public.visits;
+drop policy if exists "Staff can insert visits"   on public.visits;
+
+create policy "Staff can read all visits"
+  on public.visits for select
+  using (public.is_staff());
+
+create policy "Staff can insert visits"
+  on public.visits for insert
+  with check (public.is_staff());

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1,176 +1,95 @@
--- MedBridge HealthReach (mBHR) – Supabase Schema
--- Run this in your Supabase SQL editor to create the persistent multi-user tables.
-
--- Enable UUID generation
-create extension if not exists "uuid-ossp";
-
--- ─── patients ────────────────────────────────────────────────────────────────
--- One row per registered patient, linked to an auth.users account.
-create table if not exists public.patients (
-  id               uuid primary key default uuid_generate_v4(),
-  auth_user_id     uuid references auth.users(id) on delete cascade,
-  full_name        text not null,
-  email            text,
-  phone            text,
-  date_of_birth    date,
-  created_at       timestamptz not null default now()
-);
-
-create unique index if not exists patients_auth_user_id_idx on public.patients(auth_user_id);
-create index if not exists patients_email_idx on public.patients(email);
-
--- RLS: patients can only read/update their own row; staff (service role) has full access
-alter table public.patients enable row level security;
-
-create policy "Patient reads own record"
-  on public.patients for select
-  using (auth.uid() = auth_user_id);
-
-create policy "Patient updates own record"
-  on public.patients for update
-  using (auth.uid() = auth_user_id);
-
-create policy "Patient inserts own record"
-  on public.patients for insert
-  with check (auth.uid() = auth_user_id);
-
--- ─── visits ──────────────────────────────────────────────────────────────────
-create table if not exists public.visits (
-  id          uuid primary key default uuid_generate_v4(),
-  patient_id  uuid not null references public.patients(id) on delete cascade,
-  visit_date  timestamptz not null default now(),
-  notes       text,
-  diagnosis   text,
-  created_at  timestamptz not null default now()
-);
-
-create index if not exists visits_patient_id_idx on public.visits(patient_id);
-
-alter table public.visits enable row level security;
-
-create policy "Patient reads own visits"
-  on public.visits for select
-  using (
-    patient_id in (
-      select id from public.patients where auth_user_id = auth.uid()
-    )
-  );
-
-create policy "Staff manages visits"
-  on public.visits for all
-  using (auth.role() = 'service_role');
-
--- ─── medications ─────────────────────────────────────────────────────────────
-create table if not exists public.medications (
-  id           uuid primary key default uuid_generate_v4(),
-  patient_id   uuid not null references public.patients(id) on delete cascade,
-  name         text not null,
-  dosage       text,
-  instructions text,
-  created_at   timestamptz not null default now()
-);
-
-create index if not exists medications_patient_id_idx on public.medications(patient_id);
-
-alter table public.medications enable row level security;
-
-create policy "Patient reads own medications"
-  on public.medications for select
-  using (
-    patient_id in (
-      select id from public.patients where auth_user_id = auth.uid()
-    )
-  );
-
-create policy "Staff manages medications"
-  on public.medications for all
-  using (auth.role() = 'service_role');
-
--- ─── vitals ──────────────────────────────────────────────────────────────────
-create table if not exists public.vitals (
-  id             uuid primary key default uuid_generate_v4(),
-  patient_id     uuid not null references public.patients(id) on delete cascade,
-  blood_pressure text,
-  weight         numeric(6,2),
-  temperature    numeric(5,2),
-  recorded_at    timestamptz not null default now()
-);
-
-create index if not exists vitals_patient_id_idx on public.vitals(patient_id);
-
-alter table public.vitals enable row level security;
-
-create policy "Patient reads own vitals"
-  on public.vitals for select
-  using (
-    patient_id in (
-      select id from public.patients where auth_user_id = auth.uid()
-    )
-  );
-
-create policy "Staff manages vitals"
-  on public.vitals for all
-  using (auth.role() = 'service_role');
-
--- ─── staff_roles ─────────────────────────────────────────────────────────────
--- Tracks which auth.users are staff so the app can apply different route logic.
-create table if not exists public.staff_roles (
-  id           uuid primary key default uuid_generate_v4(),
-  auth_user_id uuid not null references auth.users(id) on delete cascade,
-  role         text not null default 'staff',   -- 'staff' | 'admin' | 'doctor' etc.
-  created_at   timestamptz not null default now()
-);
-
-create unique index if not exists staff_roles_auth_user_id_idx on public.staff_roles(auth_user_id);
-
-alter table public.staff_roles enable row level security;
-
--- Any authenticated user can check whether they are staff
-create policy "Staff reads own role"
-  on public.staff_roles for select
-  using (auth.uid() = auth_user_id);
-
--- ─── Helper: is the current user a staff member? ─────────────────────────────
-create or replace function public.is_staff()
-returns boolean
-language sql stable
-as $$
-  select exists (
-    select 1 from public.staff_roles where auth_user_id = auth.uid()
-  );
-$$;
-
--- Allow staff to read all patients
-create policy "Staff reads all patients"
-  on public.patients for select
-  using (public.is_staff());
-
--- Allow staff to read all visits
-create policy "Staff reads all visits"
-  on public.visits for select
-  using (public.is_staff());
-
--- Allow staff to read all medications
-create policy "Staff reads all medications"
-  on public.medications for select
-  using (public.is_staff());
-
--- Allow staff to read all vitals
-create policy "Staff reads all vitals"
-  on public.vitals for select
-  using (public.is_staff());
-
--- Allow staff to insert vitals
-create policy "Staff inserts vitals"
-  on public.vitals for insert
-  with check (public.is_staff());
-
--- Allow staff to insert medications
-create policy "Staff inserts medications"
-  on public.medications for insert
-  with check (public.is_staff());
-
--- Allow staff to insert visits
-create policy "Staff inserts visits"
-  on public.visits for insert
-  with check (public.is_staff());
+-- ─────────────────────────────────────────────────────────────────────────────
+-- MedBridge HealthReach (mBHR) – Supabase Schema Reference
+-- ─────────────────────────────────────────────────────────────────────────────
+-- This file is a REFERENCE ONLY.  The actual tables are created (and evolved)
+-- by the numbered migration files in supabase/migrations/.  Run migrations
+-- through the Supabase CLI:
+--
+--   supabase db push        # push local migrations to cloud
+--   supabase db pull        # pull remote schema to local
+--   supabase migration new  # scaffold a new migration file
+--
+-- ─────────────────────────────────────────────────────────────────────────────
+-- KEY TABLES (all created by existing migrations)
+-- ─────────────────────────────────────────────────────────────────────────────
+--
+-- patients
+--   id          text  PK
+--   given_name  text
+--   family_name text
+--   sex         text
+--   dob         date
+--   phone       text  (nullable)
+--   email       text  (nullable, unique)
+--   auth_uid    text  (nullable, unique) ← Supabase auth.users.id as text
+--   address     text
+--   state       text
+--   lga         text
+--   created_at  timestamptz
+--   updated_at  timestamptz
+--
+-- visits
+--   id          text  PK
+--   patient_id  text  → patients.id
+--   started_at  timestamptz
+--   site_name   text
+--   status      text  (open | closed)
+--   updated_at  timestamptz
+--
+-- vitals
+--   id          text  PK
+--   patient_id  text  → patients.id
+--   visit_id    text  → visits.id
+--   height_cm   numeric
+--   weight_kg   numeric
+--   temp_c      numeric
+--   pulse_bpm   int
+--   systolic    int
+--   diastolic   int
+--   spo2        int
+--   bmi         numeric
+--   flags       jsonb
+--   taken_at    timestamptz
+--   updated_at  timestamptz
+--
+-- consultations
+--   id               text  PK
+--   patient_id       text  → patients.id
+--   visit_id         text  → visits.id
+--   provider_name    text
+--   soap_subjective  text
+--   soap_objective   text
+--   soap_assessment  text
+--   soap_plan        text
+--   provisional_dx   text[]
+--   created_at       timestamptz
+--   updated_at       timestamptz
+--
+-- dispenses  (medications given to patients)
+--   id           text  PK
+--   patient_id   text  → patients.id
+--   visit_id     text  → visits.id
+--   item_name    text
+--   qty          int
+--   dosage       text
+--   directions   text
+--   dispensed_by text
+--   dispensed_at timestamptz
+--   updated_at   timestamptz
+--
+-- staff_roles  (added by migration 20260417000000)
+--   id              uuid  PK
+--   auth_user_id    uuid  → auth.users.id
+--   role            text  (staff | admin | doctor | nurse | pharmacist | volunteer)
+--   created_at      timestamptz
+--
+-- ─────────────────────────────────────────────────────────────────────────────
+-- ADDING A NEW STAFF MEMBER
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. Create the auth user in the Supabase dashboard (Authentication → Users)
+-- 2. Insert a staff_roles row:
+--
+--   insert into public.staff_roles (auth_user_id, role)
+--   values ('<auth-user-uuid>', 'nurse');
+--
+-- ─────────────────────────────────────────────────────────────────────────────

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,33 @@
 {
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "installCommand": "npm ci",
+  "framework": null,
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options",   "value": "nosniff" },
+        { "key": "X-Frame-Options",          "value": "DENY" },
+        { "key": "X-XSS-Protection",         "value": "1; mode=block" },
+        { "key": "Referrer-Policy",          "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy",       "value": "camera=(), microphone=(), geolocation=()" }
+      ]
+    },
+    {
+      "source": "/assets/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/sw.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=0, must-revalidate" }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Schema fixes
- patientService.ts: aligns all column names with the real existing
  Supabase migrations (given_name/family_name, auth_uid text, weight_kg,
  temp_c, taken_at, item_name/directions for dispenses, started_at for visits)
- useAuth.ts: signup now inserts into patients with the correct column names
  and casts the UUID auth user id to text to match the auth_uid text column
- PatientDashboard, PatientRegister, StaffPatientDashboard: use correct field
  names throughout (givenName, familyName, takenAt, itemName, startedAt, etc.)

New migration
- 20260417000000_add_staff_roles_and_rbac.sql: creates the staff_roles table,
  is_staff() helper, and additive RLS policies so staff can read/write all
  patient data without breaking existing patient-only policies

Supabase config
- supabase/config.toml: Supabase CLI config for local dev and GitHub Actions
  (db push runs migrations on deploy); sets auth redirect URLs for Vercel
- supabase/schema.sql: converted from conflicting DDL to a reference document
  describing the existing table layout with instructions for adding staff

Vercel config
- vercel.json: adds build/output/install commands so Vercel knows the Vite
  SPA setup; adds security headers (X-Frame-Options, X-Content-Type-Options,
  Referrer-Policy, Permissions-Policy) and cache headers for assets

Auth callback
- src/components/AuthCallback.tsx: /auth/callback route that shows a spinner
  while supabase-js exchanges the email-confirmation code for a session, then
  redirects to /patient/dashboard; shows an error after 10 s timeout
- App.tsx: /auth/callback route registered before the patient portal routes

Environment
- .env.example: comprehensive documentation of all required env vars including
  VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, VITE_APP_URL and guidance on the
  Supabase Vercel integration auto-inject

https://claude.ai/code/session_011xasv9ePvRBDy3eFEvkWxv