### PR TITLE
Improve duplicate-scan responsiveness and replace blocking alerts with toasts

### DIFF
--- a/src/pages/admin/ConflictDashboard.tsx
+++ b/src/pages/admin/ConflictDashboard.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ConflictComparisonCard";
 import { db } from "@/db";
 import { getRoleDisplayName, type Role } from "@/auth/roles";
+import { useToast } from "@/stores/toast";
 
 type TabType = "pending" | "needs_approval" | "resolved";
 
@@ -72,6 +73,7 @@ const REQUIRED_ROLE_LABELS: Record<string, { label: string; color: string }> = {
 
 export default function ConflictDashboard() {
   const { currentUser } = useAuthStore();
+  const { push: pushToast } = useToast();
   const [activeTab, setActiveTab] = useState<TabType>("pending");
   const [conflicts, setConflicts] = useState<ConflictResolution[]>([]);
   const [stats, setStats] = useState<ConflictStats | null>(null);
@@ -158,12 +160,18 @@ export default function ConflictDashboard() {
         await loadConflicts();
         await loadStats();
       }
-      alert(
-        `Scan complete. Found ${found} new potential duplicate${found !== 1 ? "s" : ""}.`,
-      );
+      pushToast({
+        id: `duplicate-scan-${Date.now()}`,
+        title: "Duplicate scan complete",
+        body: `Found ${found} new potential duplicate${found !== 1 ? "s" : ""}.`,
+      });
     } catch (error) {
       console.error("Scan failed:", error);
-      alert("Scan failed. Please try again.");
+      pushToast({
+        id: `duplicate-scan-error-${Date.now()}`,
+        title: "Duplicate scan failed",
+        body: "Please try again.",
+      });
     } finally {
       setIsScanning(false);
     }

--- a/src/services/conflictQueue.ts
+++ b/src/services/conflictQueue.ts
@@ -777,7 +777,7 @@ export class ConflictQueueService {
 
     let duplicatesFound = 0;
 
-    for (const patient of patients) {
+    for (const [index, patient] of patients.entries()) {
       const candidates = await patientDeduplication.findDuplicates({
         givenName: patient.givenName,
         familyName: patient.familyName,
@@ -812,6 +812,13 @@ export class ConflictQueueService {
           });
           duplicatesFound++;
         }
+      }
+
+      // Yield periodically so large scans don't block the UI thread and hurt INP.
+      if ((index + 1) % 10 === 0) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
       }
     }
 


### PR DESCRIPTION
### Motivation
- Duplicate scanning can run for many records and previously used `alert(...)` for feedback which blocks the main thread and hurts INP and UX.
- The scan implementation did not yield to the event loop, increasing the risk of long main-thread tasks during large scans.

### Description
- Replace blocking `alert(...)` calls in the conflict dashboard duplicate-scan flow with non-blocking toasts using `useToast` and `push` for success and error messages in `src/pages/admin/ConflictDashboard.tsx`.
- Import and use `useToast` in the dashboard and construct toast payloads with unique `id`, `title`, and `body` instead of calling `alert`.
- Update `scanForDuplicates` in `src/services/conflictQueue.ts` to iterate with `patients.entries()` and `index` and periodically `await new Promise(resolve => setTimeout(resolve, 0))` every 10 records to yield to the event loop and reduce long blocking tasks.
- Keep all existing behavior (loading conflicts/stats and creating conflict records) unchanged except for the responsiveness and notification delivery.

### Testing
- Ran `npm run typecheck` (TypeScript typecheck) and it succeeded.
- Ran `npx eslint src/pages/admin/ConflictDashboard.tsx src/services/conflictQueue.ts` and linter checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52805b7d883329b8c00ff380419f7)