### PR TITLE
Make duplicate scan robust and surface results via toasts

### DIFF
--- a/src/pages/admin/ConflictDashboard.tsx
+++ b/src/pages/admin/ConflictDashboard.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ConflictComparisonCard";
 import { db } from "@/db";
 import { getRoleDisplayName, type Role } from "@/auth/roles";
+import { useToast } from "@/stores/toast";
 
 type TabType = "pending" | "needs_approval" | "resolved";
 
@@ -72,6 +73,7 @@ const REQUIRED_ROLE_LABELS: Record<string, { label: string; color: string }> = {
 
 export default function ConflictDashboard() {
   const { currentUser } = useAuthStore();
+  const { push: pushToast } = useToast();
   const [activeTab, setActiveTab] = useState<TabType>("pending");
   const [conflicts, setConflicts] = useState<ConflictResolution[]>([]);
   const [stats, setStats] = useState<ConflictStats | null>(null);
@@ -153,17 +155,27 @@ export default function ConflictDashboard() {
   const handleScanForDuplicates = async () => {
     setIsScanning(true);
     try {
-      const found = await conflictQueueService.scanForDuplicates(50);
-      if (found > 0) {
+      const result = await conflictQueueService.scanForDuplicates(50);
+      if (result.found > 0) {
         await loadConflicts();
         await loadStats();
       }
-      alert(
-        `Scan complete. Found ${found} new potential duplicate${found !== 1 ? "s" : ""}.`,
-      );
+      const skippedMessage =
+        result.skipped > 0
+          ? ` Skipped ${result.skipped} record${result.skipped !== 1 ? "s" : ""} with invalid data.`
+          : "";
+      pushToast({
+        id: `duplicate-scan-${Date.now()}`,
+        title: "Duplicate scan complete",
+        body: `Found ${result.found} new potential duplicate${result.found !== 1 ? "s" : ""}.${skippedMessage}`,
+      });
     } catch (error) {
       console.error("Scan failed:", error);
-      alert("Scan failed. Please try again.");
+      pushToast({
+        id: `duplicate-scan-error-${Date.now()}`,
+        title: "Duplicate scan failed",
+        body: "Please try again.",
+      });
     } finally {
       setIsScanning(false);
     }

--- a/src/services/conflictQueue.ts
+++ b/src/services/conflictQueue.ts
@@ -766,56 +766,78 @@ export class ConflictQueueService {
     return { success, failed };
   }
 
-  async scanForDuplicates(limit = 100): Promise<number> {
+  async scanForDuplicates(
+    limit = 100,
+  ): Promise<{ found: number; skipped: number }> {
     const patients = await db.patients
-      .where("mergeInto")
-      .equals("")
-      .or("mergeInto")
-      .equals(undefined as unknown as string)
+      .filter((patient) => !patient.mergeInto)
       .limit(limit)
       .toArray();
 
     let duplicatesFound = 0;
+    let skippedRecords = 0;
 
-    for (const patient of patients) {
-      const candidates = await patientDeduplication.findDuplicates({
-        givenName: patient.givenName,
-        familyName: patient.familyName,
-        phone: patient.phone || undefined,
-        dob: new Date(patient.dob),
-        address: patient.address,
-      });
-
-      const otherCandidates = candidates.filter(
-        (c) => c.patient.id !== patient.id,
-      );
-
-      if (otherCandidates.length > 0) {
-        const existing = await this.checkExistingConflict(
-          patient.id,
-          "duplicate",
-        );
-        if (!existing) {
-          await this.createConflict({
-            conflictType: "duplicate",
-            entityType: "patients",
-            entityId: patient.id,
-            candidateIds: otherCandidates.map((c) => c.patient.id),
-            conflictDetails: {
-              fields: this.buildDuplicateFields(
-                patient,
-                otherCandidates[0].patient,
-              ),
-              matchScore: otherCandidates[0].score,
-              matchReasons: otherCandidates[0].matchReasons,
-            },
-          });
-          duplicatesFound++;
+    for (const [index, patient] of patients.entries()) {
+      try {
+        const dob = new Date(patient.dob);
+        const hasValidDob = Number.isFinite(dob.getTime());
+        if (!hasValidDob || !patient.givenName || !patient.familyName) {
+          skippedRecords++;
+          continue;
         }
+
+        const candidates = await patientDeduplication.findDuplicates({
+          givenName: patient.givenName,
+          familyName: patient.familyName,
+          phone: patient.phone || undefined,
+          dob,
+          address: patient.address,
+        });
+
+        const otherCandidates = candidates.filter(
+          (c) => c.patient.id !== patient.id,
+        );
+
+        if (otherCandidates.length > 0) {
+          const existing = await this.checkExistingConflict(
+            patient.id,
+            "duplicate",
+          );
+          if (!existing) {
+            await this.createConflict({
+              conflictType: "duplicate",
+              entityType: "patients",
+              entityId: patient.id,
+              candidateIds: otherCandidates.map((c) => c.patient.id),
+              conflictDetails: {
+                fields: this.buildDuplicateFields(
+                  patient,
+                  otherCandidates[0].patient,
+                ),
+                matchScore: otherCandidates[0].score,
+                matchReasons: otherCandidates[0].matchReasons,
+              },
+            });
+            duplicatesFound++;
+          }
+        }
+      } catch (error) {
+        skippedRecords++;
+        logger.warn("Skipping patient during duplicate scan", {
+          patientId: patient.id,
+          error,
+        });
+      }
+
+      // Yield periodically so large scans don't block the UI thread and hurt INP.
+      if ((index + 1) % 10 === 0) {
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 0);
+        });
       }
     }
 
-    return duplicatesFound;
+    return { found: duplicatesFound, skipped: skippedRecords };
   }
 
   private async checkExistingConflict(


### PR DESCRIPTION
### Motivation
- Prevent the duplicate scanning process from failing or blocking the UI due to invalid patient data and long synchronous loops.
- Provide clearer user feedback for the scan results instead of blocking `alert` dialogs.

### Description
- Change `ConflictQueueService.scanForDuplicates` to return `{ found: number; skipped: number }` instead of a single number and update the caller accordingly.
- Skip patients with missing name fields or invalid DOBs and count skipped records, with per-patient `try/catch` logging to avoid aborting the whole scan on errors.
- Replace the DB query predicate with a `filter((p) => !p.mergeInto)` to handle empty/undefined `mergeInto` consistently.
- Yield periodically during scanning (every 10 processed patients) using `setTimeout` to avoid blocking the UI thread and hurting interaction metrics.
- Replace `alert` calls in `ConflictDashboard.handleScanForDuplicates` with toasts via `useToast`, displaying both found and skipped counts and showing a toast on error.

### Testing
- Ran TypeScript build (`yarn build`) and the compile succeeded.
- Ran the test suite (`yarn test`) and the tests passed.
- Ran linting (`yarn lint`) with no new lint errors detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52805b7d883329b8c00ff380419f7)