### PR TITLE
Improve Palaver Room Supabase configuration diagnostics

### DIFF
--- a/src/features/doctor/PalaverRoom.tsx
+++ b/src/features/doctor/PalaverRoom.tsx
@@ -74,8 +74,10 @@ export function PalaverRoom({ onClose, isPanel = false }: PalaverRoomProps) {
     setLoadError("");
 
     if (!palaverRoom.isAvailable()) {
+      const status = palaverRoom.getAvailabilityStatus();
       setLoadError(
-        "Messaging service is not configured. Please check your database connection.",
+        status.details ||
+          "Messaging service is not configured. Please check your database connection.",
       );
       setLoading(false);
       return;

--- a/src/services/palaverRoom.ts
+++ b/src/services/palaverRoom.ts
@@ -61,7 +61,49 @@ export interface SendBroadcastParams {
   expiresAt?: Date;
 }
 
+export interface PalaverAvailabilityStatus {
+  available: boolean;
+  reason?: string;
+  details?: string;
+}
+
 class PalaverRoomService {
+  getAvailabilityStatus(): PalaverAvailabilityStatus {
+    const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+    const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as
+      | string
+      | undefined;
+
+    if (!url || !anonKey) {
+      return {
+        available: false,
+        reason: "supabase_env_missing",
+        details:
+          "Missing VITE_SUPABASE_URL and/or VITE_SUPABASE_ANON_KEY in the client environment.",
+      };
+    }
+
+    if (url === "your_supabase_project_url_here") {
+      return {
+        available: false,
+        reason: "supabase_env_placeholder",
+        details:
+          "VITE_SUPABASE_URL is still set to a placeholder value and not a real Supabase project URL.",
+      };
+    }
+
+    if (!supabase) {
+      return {
+        available: false,
+        reason: "supabase_client_init_failed",
+        details:
+          "Supabase client initialization failed in the browser at runtime.",
+      };
+    }
+
+    return { available: true };
+  }
+
   async sendMessage(params: SendMessageParams): Promise<PalaverMessage | null> {
     if (!supabase) {
       logger.warn("Supabase not configured - message not sent");
@@ -212,7 +254,7 @@ class PalaverRoomService {
   }
 
   isAvailable(): boolean {
-    return supabase !== null;
+    return this.getAvailabilityStatus().available;
   }
 
   async markAsRead(messageId: string): Promise<void> {


### PR DESCRIPTION
### Motivation
- Make the Palaver Room failure mode obvious and actionable by surfacing the root cause when the staff messaging UI cannot initialize. 
- Confirm that internal staff messaging stays separate from patient messaging (uses `palaver_messages` / `palaver_broadcasts`).

### Description
- Add `PalaverAvailabilityStatus` and `getAvailabilityStatus()` to `palaverRoom` service to detect and report missing env vars, placeholder URL values, or runtime Supabase client init failures. 
- Change `isAvailable()` to return the availability from `getAvailabilityStatus()` and update the Palaver Room UI (`PalaverRoom.tsx`) to display the service `details` text when unavailable instead of a generic error. 
- No changes to patient messaging: Palaver Room continues to use `palaver_messages`/`palaver_broadcasts` and remains separated from `patient_messages`.

### Testing
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully. 
- Ran `npx eslint src/services/palaverRoom.ts src/features/doctor/PalaverRoom.tsx` and linting passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52c5e6c8883328137e32b4abe94e5)