### PR TITLE
Improve Supabase env handling: client-side mapping and availability diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ To enable cloud sync, add Supabase configuration to `.env`:
 ```
 VITE_SUPABASE_URL=your_supabase_url
 VITE_SUPABASE_ANON_KEY=your_anon_key
+
+# Optional on Vercel with Supabase integration:
+# If only SUPABASE_URL / SUPABASE_ANON_KEY are set, the Vite build now maps
+# them automatically to the client VITE_ variables.
 ```
 
 Then run the SQL migration to create the database schema:
@@ -106,14 +110,17 @@ The app will automatically detect the configuration and enable background sync!
 ### Migration File Location
 
 The complete SQL migration is located at:
+
 ```
 supabase/migrations/create_sync_schema.sql
 ```
 
 This migration creates all necessary tables, indexes, and Row Level Security policies for syncing your offline data with Supabase.
+
 ## Acceptance Tests
 
 ### A1: First Run Setup
+
 - App shows Admin Setup screen
 - Create admin with Setup PIN
 - Create additional users
@@ -121,36 +128,43 @@ This migration creates all necessary tables, indexes, and Row Level Security pol
 - Dashboard shows with offline badge
 
 ### A2: Patient Registration
+
 - Register patient with photo
 - Start visit
 - Patient appears in queue
 
 ### A3: Vitals Recording
+
 - Enter vital signs
 - BMI auto-calculates
 - Abnormal values trigger flags
 
 ### A4: Consultation
+
 - Add SOAP notes
 - Record provisional diagnosis
 - Save offline
 
 ### A5: Pharmacy
+
 - Dispense medication
 - Inventory decrements
 - Low stock warnings
 
 ### A6: Offline Resilience
+
 - Disable internet
 - Hard refresh
 - Data persists
 - Register new patient
 
 ### A7: Data Export
+
 - Export CSV files
 - Verify data integrity
 
 ### A8: Online Sync (Optional)
+
 - Add Supabase keys
 - Online login available
 - Offline PIN still works
@@ -161,6 +175,7 @@ This migration creates all necessary tables, indexes, and Row Level Security pol
 The app is built with strict TypeScript, ESLint, and includes error boundaries to catch JSX mistakes early.
 
 Key directories:
+
 - `/src/db` - Database schema and utilities
 - `/src/stores` - Zustand state management
 - `/src/components` - Reusable UI components

--- a/src/features/doctor/PalaverRoom.tsx
+++ b/src/features/doctor/PalaverRoom.tsx
@@ -74,8 +74,10 @@ export function PalaverRoom({ onClose, isPanel = false }: PalaverRoomProps) {
     setLoadError("");
 
     if (!palaverRoom.isAvailable()) {
+      const status = palaverRoom.getAvailabilityStatus();
       setLoadError(
-        "Messaging service is not configured. Please check your database connection.",
+        status.details ||
+          "Messaging service is not configured. Please check your database connection.",
       );
       setLoading(false);
       return;

--- a/src/services/palaverRoom.ts
+++ b/src/services/palaverRoom.ts
@@ -61,7 +61,49 @@ export interface SendBroadcastParams {
   expiresAt?: Date;
 }
 
+export interface PalaverAvailabilityStatus {
+  available: boolean;
+  reason?: string;
+  details?: string;
+}
+
 class PalaverRoomService {
+  getAvailabilityStatus(): PalaverAvailabilityStatus {
+    const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+    const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as
+      | string
+      | undefined;
+
+    if (!url || !anonKey) {
+      return {
+        available: false,
+        reason: "supabase_env_missing",
+        details:
+          "Missing VITE_SUPABASE_URL and/or VITE_SUPABASE_ANON_KEY in the client environment.",
+      };
+    }
+
+    if (url === "your_supabase_project_url_here") {
+      return {
+        available: false,
+        reason: "supabase_env_placeholder",
+        details:
+          "VITE_SUPABASE_URL is still set to a placeholder value and not a real Supabase project URL.",
+      };
+    }
+
+    if (!supabase) {
+      return {
+        available: false,
+        reason: "supabase_client_init_failed",
+        details:
+          "Supabase client initialization failed in the browser at runtime.",
+      };
+    }
+
+    return { available: true };
+  }
+
   async sendMessage(params: SendMessageParams): Promise<PalaverMessage | null> {
     if (!supabase) {
       logger.warn("Supabase not configured - message not sent");
@@ -212,7 +254,7 @@ class PalaverRoomService {
   }
 
   isAvailable(): boolean {
-    return supabase !== null;
+    return this.getAvailabilityStatus().available;
   }
 
   async markAsRead(messageId: string): Promise<void> {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,18 @@ import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import { resolve } from "path";
 
+const clientSupabaseUrl =
+  process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL || "";
+const clientSupabaseAnonKey =
+  process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY || "";
+
 export default defineConfig({
+  define: {
+    "import.meta.env.VITE_SUPABASE_URL": JSON.stringify(clientSupabaseUrl),
+    "import.meta.env.VITE_SUPABASE_ANON_KEY": JSON.stringify(
+      clientSupabaseAnonKey,
+    ),
+  },
   resolve: {
     alias: {
       "@": resolve(__dirname, "./src"),


### PR DESCRIPTION
### Motivation

- Make the app more resilient to misconfigured Supabase environment variables and surface actionable errors to the UI when messaging is unavailable.
- Allow deployments (e.g. Vercel) that set `SUPABASE_URL`/`SUPABASE_ANON_KEY` (without `VITE_` prefix) to still provide values to the client-side code.
- Clarify README with a note about optional Vercel/Supabase mapping and tidy a few formatting/newline issues.

### Description

- Added `getAvailabilityStatus()` and `PalaverAvailabilityStatus` in `src/services/palaverRoom.ts` to detect missing/placeholder env vars and client initialization failures and return diagnostic details.  
- Switched `isAvailable()` to use the new `getAvailabilityStatus()` and updated `src/features/doctor/PalaverRoom.tsx` to show `status.details` in the load error message when available.  
- Updated `vite.config.ts` to map `process.env.SUPABASE_URL`/`process.env.SUPABASE_ANON_KEY` into `import.meta.env.VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` at build time so plain `SUPABASE_*` envs are picked up by the Vite client.  
- Small README updates to document the optional Vercel/Supabase mapping and fix formatting/newline issues.

### Testing

- Ran a production build with `npm run build` and the Vite build completed successfully.  
- Ran ESLint with `npm run lint` and no new lint errors were reported.  
- Verified the Palaver availability path by starting the app with and without Supabase env vars and confirmed the diagnostic message is shown in the UI when missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52c5e6c8883328137e32b4abe94e5)