### PR TITLE
Supabase availability checks, client env mapping, CI build, and extended Supabase migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build Check
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - mainone
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ To enable cloud sync, add Supabase configuration to `.env`:
 ```
 VITE_SUPABASE_URL=your_supabase_url
 VITE_SUPABASE_ANON_KEY=your_anon_key
+
+# Optional on Vercel with Supabase integration:
+# If only SUPABASE_URL / SUPABASE_ANON_KEY are set, the Vite build now maps
+# them automatically to the client VITE_ variables.
 ```
 
 Then run the SQL migration to create the database schema:
@@ -106,14 +110,17 @@ The app will automatically detect the configuration and enable background sync!
 ### Migration File Location
 
 The complete SQL migration is located at:
+
 ```
 supabase/migrations/create_sync_schema.sql
 ```
 
 This migration creates all necessary tables, indexes, and Row Level Security policies for syncing your offline data with Supabase.
+
 ## Acceptance Tests
 
 ### A1: First Run Setup
+
 - App shows Admin Setup screen
 - Create admin with Setup PIN
 - Create additional users
@@ -121,36 +128,43 @@ This migration creates all necessary tables, indexes, and Row Level Security pol
 - Dashboard shows with offline badge
 
 ### A2: Patient Registration
+
 - Register patient with photo
 - Start visit
 - Patient appears in queue
 
 ### A3: Vitals Recording
+
 - Enter vital signs
 - BMI auto-calculates
 - Abnormal values trigger flags
 
 ### A4: Consultation
+
 - Add SOAP notes
 - Record provisional diagnosis
 - Save offline
 
 ### A5: Pharmacy
+
 - Dispense medication
 - Inventory decrements
 - Low stock warnings
 
 ### A6: Offline Resilience
+
 - Disable internet
 - Hard refresh
 - Data persists
 - Register new patient
 
 ### A7: Data Export
+
 - Export CSV files
 - Verify data integrity
 
 ### A8: Online Sync (Optional)
+
 - Add Supabase keys
 - Online login available
 - Offline PIN still works
@@ -161,6 +175,7 @@ This migration creates all necessary tables, indexes, and Row Level Security pol
 The app is built with strict TypeScript, ESLint, and includes error boundaries to catch JSX mistakes early.
 
 Key directories:
+
 - `/src/db` - Database schema and utilities
 - `/src/stores` - Zustand state management
 - `/src/components` - Reusable UI components

--- a/src/features/doctor/PalaverRoom.tsx
+++ b/src/features/doctor/PalaverRoom.tsx
@@ -74,8 +74,10 @@ export function PalaverRoom({ onClose, isPanel = false }: PalaverRoomProps) {
     setLoadError("");
 
     if (!palaverRoom.isAvailable()) {
+      const status = palaverRoom.getAvailabilityStatus();
       setLoadError(
-        "Messaging service is not configured. Please check your database connection.",
+        status.details ||
+          "Messaging service is not configured. Please check your database connection.",
       );
       setLoading(false);
       return;

--- a/src/services/palaverRoom.ts
+++ b/src/services/palaverRoom.ts
@@ -61,7 +61,49 @@ export interface SendBroadcastParams {
   expiresAt?: Date;
 }
 
+export interface PalaverAvailabilityStatus {
+  available: boolean;
+  reason?: string;
+  details?: string;
+}
+
 class PalaverRoomService {
+  getAvailabilityStatus(): PalaverAvailabilityStatus {
+    const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+    const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as
+      | string
+      | undefined;
+
+    if (!url || !anonKey) {
+      return {
+        available: false,
+        reason: "supabase_env_missing",
+        details:
+          "Missing VITE_SUPABASE_URL and/or VITE_SUPABASE_ANON_KEY in the client environment.",
+      };
+    }
+
+    if (url === "your_supabase_project_url_here") {
+      return {
+        available: false,
+        reason: "supabase_env_placeholder",
+        details:
+          "VITE_SUPABASE_URL is still set to a placeholder value and not a real Supabase project URL.",
+      };
+    }
+
+    if (!supabase) {
+      return {
+        available: false,
+        reason: "supabase_client_init_failed",
+        details:
+          "Supabase client initialization failed in the browser at runtime.",
+      };
+    }
+
+    return { available: true };
+  }
+
   async sendMessage(params: SendMessageParams): Promise<PalaverMessage | null> {
     if (!supabase) {
       logger.warn("Supabase not configured - message not sent");
@@ -212,7 +254,7 @@ class PalaverRoomService {
   }
 
   isAvailable(): boolean {
-    return supabase !== null;
+    return this.getAvailabilityStatus().available;
   }
 
   async markAsRead(messageId: string): Promise<void> {

--- a/supabase/migrations/20250930065243_empty_band.sql
+++ b/supabase/migrations/20250930065243_empty_band.sql
@@ -1,0 +1,282 @@
+-- MBHR (Med Bridge Health Reach) Extended Schema
+-- Non-medical inventory, Pharmacy, and Ticketing systems
+
+-- Non-medical inventory
+create table if not exists inventory_nm (
+  id text primary key,
+  item_name text not null,
+  unit text not null,
+  on_hand_qty int not null default 0,
+  reorder_threshold int not null default 0,
+  min_qty int,
+  max_qty int,
+  updated_at timestamptz not null default now(),
+  site_id text
+);
+create index if not exists idx_inventory_nm_item on inventory_nm (item_name);
+create index if not exists idx_inventory_nm_updated on inventory_nm (updated_at);
+create index if not exists idx_inventory_nm_threshold on inventory_nm (reorder_threshold);
+
+-- Enable RLS
+alter table inventory_nm enable row level security;
+create policy "Allow authenticated access to inventory_nm"
+  on inventory_nm
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+create table if not exists stock_moves_nm (
+  id text primary key,
+  item_id text not null references inventory_nm(id) on delete cascade,
+  qty_delta int not null,
+  reason text not null check (reason in ('restock','consume','adjust')),
+  actor_id text,
+  note text,
+  created_at timestamptz not null default now(),
+  approved_by text,
+  approved_at timestamptz
+);
+create index if not exists idx_stock_moves_nm_created on stock_moves_nm (created_at);
+
+alter table stock_moves_nm enable row level security;
+create policy "Allow authenticated access to stock_moves_nm"
+  on stock_moves_nm
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+create table if not exists gamification (
+  id text primary key,
+  volunteer_id text not null,
+  tokens int not null default 0,
+  badges text[] not null default '{}',
+  updated_at timestamptz not null default now()
+);
+
+alter table gamification enable row level security;
+create policy "Allow authenticated access to gamification"
+  on gamification
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+create table if not exists restock_sessions (
+  id text primary key,
+  volunteer_id text not null,
+  started_at timestamptz not null default now(),
+  finished_at timestamptz,
+  deltas jsonb not null default '[]',
+  tokens_earned int not null default 0,
+  committed boolean not null default false
+);
+
+alter table restock_sessions enable row level security;
+create policy "Allow authenticated access to restock_sessions"
+  on restock_sessions
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+create table if not exists alerts_nm (
+  id text primary key,
+  item_id text not null references inventory_nm(id) on delete cascade,
+  level text not null check (level in ('low','critical')),
+  triggered_at timestamptz not null,
+  cleared_at timestamptz
+);
+
+alter table alerts_nm enable row level security;
+create policy "Allow authenticated access to alerts_nm"
+  on alerts_nm
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+-- Pharmacy
+create table if not exists pharmacy_items (
+  id text primary key,
+  med_name text not null,
+  form text not null,
+  strength text not null,
+  unit text not null,
+  on_hand_qty int not null default 0,
+  reorder_threshold int not null default 0,
+  is_controlled boolean not null default false,
+  updated_at timestamptz not null default now()
+);
+create index if not exists idx_pharmacy_items_name on pharmacy_items (med_name);
+
+alter table pharmacy_items enable row level security;
+create policy "Allow authenticated access to pharmacy_items"
+  on pharmacy_items
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+create table if not exists pharmacy_batches (
+  id text primary key,
+  item_id text not null references pharmacy_items(id) on delete cascade,
+  lot_number text not null,
+  expiry_date date not null,
+  qty_on_hand int not null default 0,
+  received_at date not null default now(),
+  supplier text
+);
+create index if not exists idx_pharmacy_batches_expiry on pharmacy_batches (expiry_date);
+
+alter table pharmacy_batches enable row level security;
+create policy "Allow authenticated access to pharmacy_batches"
+  on pharmacy_batches
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+create table if not exists prescriptions (
+  id text primary key,
+  visit_id text not null,
+  patient_id text not null,
+  prescriber_id text not null,
+  lines jsonb not null,
+  created_at timestamptz not null default now(),
+  status text not null check (status in ('open','dispensed','partial','void'))
+);
+
+alter table prescriptions enable row level security;
+create policy "Allow authenticated access to prescriptions"
+  on prescriptions
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+create table if not exists dispenses (
+  id text primary key,
+  prescription_id text not null references prescriptions(id) on delete cascade,
+  patient_id text not null,
+  item_id text not null references pharmacy_items(id) on delete restrict,
+  batch_id text not null references pharmacy_batches(id) on delete restrict,
+  qty int not null,
+  dispensed_by text not null,
+  dispensed_at timestamptz not null default now()
+);
+
+alter table dispenses enable row level security;
+create policy "Allow authenticated access to dispenses"
+  on dispenses
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+create table if not exists stock_moves_rx (
+  id text primary key,
+  item_id text not null references pharmacy_items(id) on delete cascade,
+  batch_id text references pharmacy_batches(id) on delete set null,
+  qty_delta int not null,
+  reason text not null check (reason in ('receipt','dispense','adjust')),
+  actor_id text,
+  created_at timestamptz not null default now()
+);
+create index if not exists idx_stock_moves_rx_created on stock_moves_rx (created_at);
+
+alter table stock_moves_rx enable row level security;
+create policy "Allow authenticated access to stock_moves_rx"
+  on stock_moves_rx
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+-- Ticketing
+create table if not exists tickets (
+  id text primary key,
+  number text not null,
+  patient_id text,
+  category text not null,
+  priority text not null,
+  created_at timestamptz not null default now(),
+  site_id text not null,
+  state text not null check (state in ('waiting','in_progress','done','skipped')),
+  current_stage text not null
+);
+create index if not exists idx_tickets_stage_state on tickets (current_stage, state);
+
+alter table tickets enable row level security;
+create policy "Allow authenticated access to tickets"
+  on tickets
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+create table if not exists stage_events (
+  id text primary key,
+  ticket_id text not null references tickets(id) on delete cascade,
+  stage text not null,
+  started_at timestamptz,
+  finished_at timestamptz,
+  actor_id text
+);
+
+alter table stage_events enable row level security;
+create policy "Allow authenticated access to stage_events"
+  on stage_events
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+create table if not exists queue_metrics (
+  id text primary key,
+  stage text not null,
+  avg_service_sec int not null default 240,
+  updated_at timestamptz not null default now()
+);
+
+alter table queue_metrics enable row level security;
+create policy "Allow authenticated access to queue_metrics"
+  on queue_metrics
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+create table if not exists notifications (
+  id text primary key,
+  ticket_id text not null references tickets(id) on delete cascade,
+  channel text not null,
+  payload jsonb not null,
+  sent_at timestamptz,
+  status text not null default 'queued'
+);
+
+alter table notifications enable row level security;
+create policy "Allow authenticated access to notifications"
+  on notifications
+  for all
+  to authenticated
+  using (true)
+  with check (true);
+
+create table if not exists daily_counters (
+  id text primary key,
+  site_id text not null,
+  date_str text not null,
+  category text not null,
+  seq int not null default 0
+);
+
+alter table daily_counters enable row level security;
+create policy "Allow authenticated access to daily_counters"
+  on daily_counters
+  for all
+  to authenticated
+  using (true)
+  with check (true);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,18 @@ import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import { resolve } from "path";
 
+const clientSupabaseUrl =
+  process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL || "";
+const clientSupabaseAnonKey =
+  process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY || "";
+
 export default defineConfig({
+  define: {
+    "import.meta.env.VITE_SUPABASE_URL": JSON.stringify(clientSupabaseUrl),
+    "import.meta.env.VITE_SUPABASE_ANON_KEY": JSON.stringify(
+      clientSupabaseAnonKey,
+    ),
+  },
   resolve: {
     alias: {
       "@": resolve(__dirname, "./src"),


### PR DESCRIPTION
### Motivation

- Surface clearer runtime reasons when the Supabase messaging service is unavailable so the UI can show actionable details.
- Allow build-time mapping of server-side Supabase env vars into the client so Vite-built clients can use `import.meta.env.VITE_SUPABASE_*` values even when only `SUPABASE_*` are provided by the host.
- Ensure TypeScript typechecking and build steps run automatically on PRs and pushes to catch regressions early.
- Add an extended Supabase migration to support non-medical inventory, pharmacy, and ticketing features.

### Description

- Added `PalaverAvailabilityStatus` and `getAvailabilityStatus()` to `src/services/palaverRoom.ts` and changed `isAvailable()` to use the new availability check returning detailed reasons when env vars are missing, placeholders are present, or client init fails.
- Updated `src/features/doctor/PalaverRoom.tsx` to call `palaverRoom.getAvailabilityStatus()` and display `status.details` in load error messages.
- Added client env mapping in `vite.config.ts` so `import.meta.env.VITE_SUPABASE_URL` and `import.meta.env.VITE_SUPABASE_ANON_KEY` are defined from `process.env.VITE_SUPABASE_*` or `process.env.SUPABASE_*` at build time.
- Added a GitHub Actions workflow `.github/workflows/build.yml` named `Build Check` to run `npm ci`, `npm run typecheck`, and `npm run build` on PRs and pushes to `main` and `mainone`.
- Introduced a new Supabase migration `supabase/migrations/20250930065243_empty_band.sql` adding tables, indexes, and RLS policies for inventory (non-medical), pharmacy, prescriptions/dispenses, ticketing, and related utilities.

### Testing

- Added a CI workflow to run automated checks (`npm ci`, `npm run typecheck`, `npm run build`) on PRs and pushes to `main`/`mainone`.
- Executed `npm run typecheck` locally and it completed successfully.
- Executed `npm run build` locally and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e52c5e6c8883328137e32b4abe94e5)