### PR TITLE
Add doctor Patient Messages panel and secure messaging service

### DIFF
--- a/src/features/doctor/PatientMessagesPanel.tsx
+++ b/src/features/doctor/PatientMessagesPanel.tsx
@@ -1,0 +1,390 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ArrowLeftIcon,
+  PencilSquareIcon,
+  MagnifyingGlassIcon,
+  PaperAirplaneIcon,
+  XMarkIcon,
+  InboxIcon,
+} from "@heroicons/react/24/outline";
+import { useAuthStore } from "@/stores/auth";
+import {
+  getDoctorMessageInbox,
+  getDoctorUnreadCount,
+  markMessageRead,
+  searchPatientsByName,
+  sendDoctorMessage,
+  type PatientSearchResult,
+  type PatientSecureMessage,
+} from "@/services/patientSecureMessaging";
+
+type ViewMode = "inbox" | "compose";
+
+interface PatientMessagesPanelProps {
+  onClose?: () => void;
+  onUnreadChange?: (count: number) => void;
+}
+
+export function PatientMessagesPanel({
+  onClose,
+  onUnreadChange,
+}: PatientMessagesPanelProps) {
+  const { currentUser } = useAuthStore();
+  const [viewMode, setViewMode] = useState<ViewMode>("inbox");
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [messages, setMessages] = useState<PatientSecureMessage[]>([]);
+  const [patientNames, setPatientNames] = useState<Map<string, string>>(
+    new Map(),
+  );
+  const [error, setError] = useState("");
+
+  const [query, setQuery] = useState("");
+  const [patientResults, setPatientResults] = useState<PatientSearchResult[]>(
+    [],
+  );
+  const [selectedPatient, setSelectedPatient] =
+    useState<PatientSearchResult | null>(null);
+  const [subject, setSubject] = useState("");
+  const [body, setBody] = useState("");
+
+  const loadData = useCallback(async () => {
+    if (!currentUser?.id) return;
+    setLoading(true);
+    setError("");
+
+    try {
+      const [{ messages: inboxMessages, patientNames: names }, unread] =
+        await Promise.all([
+          getDoctorMessageInbox(currentUser.id),
+          getDoctorUnreadCount(currentUser.id),
+        ]);
+      setMessages(inboxMessages);
+      setPatientNames(names);
+      onUnreadChange?.(unread);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load messages");
+    } finally {
+      setLoading(false);
+    }
+  }, [currentUser?.id, onUnreadChange]);
+
+  useEffect(() => {
+    loadData();
+    const timer = setInterval(loadData, 30000);
+    return () => clearInterval(timer);
+  }, [loadData]);
+
+  useEffect(() => {
+    const search = async () => {
+      if (query.trim().length < 2) {
+        setPatientResults([]);
+        return;
+      }
+
+      try {
+        const results = await searchPatientsByName(query);
+        setPatientResults(results);
+      } catch {
+        setPatientResults([]);
+      }
+    };
+
+    const timeout = setTimeout(search, 200);
+    return () => clearTimeout(timeout);
+  }, [query]);
+
+  const openCompose = () => {
+    setViewMode("compose");
+    setError("");
+  };
+
+  const resetCompose = () => {
+    setQuery("");
+    setPatientResults([]);
+    setSelectedPatient(null);
+    setSubject("");
+    setBody("");
+  };
+
+  const handleSend = async () => {
+    if (!currentUser) return;
+    if (!selectedPatient || !subject.trim() || !body.trim()) {
+      setError("Please select a patient and fill in subject and message.");
+      return;
+    }
+
+    setSending(true);
+    setError("");
+
+    try {
+      await sendDoctorMessage({
+        staffId: currentUser.id,
+        staffName: currentUser.fullName,
+        patientId: selectedPatient.id,
+        subject,
+        body,
+      });
+      resetCompose();
+      setViewMode("inbox");
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to send message");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const groupedMessages = useMemo(() => {
+    const map = new Map<string, PatientSecureMessage[]>();
+    messages.forEach((message) => {
+      const existing = map.get(message.patient_id) || [];
+      existing.push(message);
+      map.set(message.patient_id, existing);
+    });
+
+    return Array.from(map.entries())
+      .map(([patientId, thread]) => ({
+        patientId,
+        patientName:
+          patientNames.get(patientId) || `Patient ${patientId.slice(0, 8)}`,
+        latest: thread[0],
+        unread: thread.filter((m) => m.from_patient && !m.read).length,
+      }))
+      .sort(
+        (a, b) =>
+          new Date(b.latest.created_at).getTime() -
+          new Date(a.latest.created_at).getTime(),
+      );
+  }, [messages, patientNames]);
+
+  const openThreadPreview = async (message: PatientSecureMessage) => {
+    if (!message.read && message.from_patient) {
+      try {
+        await markMessageRead(message.id);
+        await loadData();
+      } catch {
+        // non-blocking
+      }
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-lg overflow-hidden h-full flex flex-col">
+      <div className="bg-gradient-to-r from-indigo-600 to-blue-600 text-white p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            {viewMode === "compose" ? (
+              <button
+                onClick={() => {
+                  setViewMode("inbox");
+                  setError("");
+                }}
+                className="p-1 hover:bg-white/20 rounded-lg"
+              >
+                <ArrowLeftIcon className="h-5 w-5" />
+              </button>
+            ) : null}
+            <div>
+              <h2 className="text-xl font-bold">Patient Messages</h2>
+              <p className="text-sm text-blue-100">
+                {viewMode === "compose" ? "New Message" : "Inbox"}
+              </p>
+            </div>
+          </div>
+          <div className="flex items-center gap-1">
+            {viewMode === "inbox" && (
+              <button
+                onClick={openCompose}
+                className="p-2 hover:bg-white/20 rounded-lg"
+                aria-label="Compose new message"
+              >
+                <PencilSquareIcon className="h-5 w-5" />
+              </button>
+            )}
+            {onClose && (
+              <button
+                onClick={onClose}
+                className="p-2 hover:bg-white/20 rounded-lg"
+              >
+                <XMarkIcon className="h-5 w-5" />
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="m-4 p-3 bg-red-50 border border-red-200 rounded text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto p-4">
+        {loading ? (
+          <div className="py-10 flex justify-center">
+            <div className="h-8 w-8 rounded-full border-b-2 border-blue-600 animate-spin" />
+          </div>
+        ) : viewMode === "compose" ? (
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                To (Patient) *
+              </label>
+              {!selectedPatient ? (
+                <div className="space-y-2">
+                  <div className="relative">
+                    <MagnifyingGlassIcon className="h-5 w-5 text-gray-400 absolute left-3 top-1/2 -translate-y-1/2" />
+                    <input
+                      type="text"
+                      value={query}
+                      onChange={(e) => setQuery(e.target.value)}
+                      placeholder="Search patient by name..."
+                      className="w-full pl-10 pr-3 py-2 border border-gray-300 rounded-lg"
+                    />
+                  </div>
+
+                  {patientResults.length > 0 && (
+                    <div className="border rounded-lg max-h-40 overflow-y-auto divide-y">
+                      {patientResults.map((patient) => (
+                        <button
+                          key={patient.id}
+                          type="button"
+                          onClick={() => {
+                            setSelectedPatient(patient);
+                            setQuery(patient.fullName);
+                            setPatientResults([]);
+                          }}
+                          className="w-full text-left px-3 py-2 hover:bg-gray-50"
+                        >
+                          {patient.fullName}
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <div className="flex items-center justify-between border border-blue-200 bg-blue-50 rounded-lg px-3 py-2">
+                  <span className="text-sm font-medium text-blue-900">
+                    {selectedPatient.fullName}
+                  </span>
+                  <button
+                    type="button"
+                    className="text-xs text-blue-700"
+                    onClick={() => {
+                      setSelectedPatient(null);
+                      setQuery("");
+                    }}
+                  >
+                    Change
+                  </button>
+                </div>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Subject *
+              </label>
+              <input
+                type="text"
+                value={subject}
+                onChange={(e) => setSubject(e.target.value)}
+                placeholder="Message subject"
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Message *
+              </label>
+              <textarea
+                value={body}
+                onChange={(e) => setBody(e.target.value)}
+                rows={7}
+                placeholder="Type your message to the patient..."
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg resize-none"
+              />
+            </div>
+
+            <div className="flex gap-2 pt-1">
+              <button
+                onClick={handleSend}
+                disabled={sending}
+                className="flex-1 py-2 px-3 bg-blue-600 text-white rounded-lg disabled:opacity-50 flex items-center justify-center gap-2"
+              >
+                {sending ? (
+                  <div className="h-4 w-4 rounded-full border-b-2 border-white animate-spin" />
+                ) : (
+                  <>
+                    <PaperAirplaneIcon className="h-4 w-4" /> Send Message
+                  </>
+                )}
+              </button>
+              <button
+                onClick={() => {
+                  resetCompose();
+                  setViewMode("inbox");
+                }}
+                className="px-4 py-2 border border-gray-300 rounded-lg"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : groupedMessages.length === 0 ? (
+          <div className="text-center py-16">
+            <InboxIcon className="h-12 w-12 text-gray-300 mx-auto mb-3" />
+            <p className="font-medium text-gray-900">No patient messages yet</p>
+            <p className="text-sm text-gray-500 mt-1 mb-4">
+              Start a conversation to message a patient in their portal.
+            </p>
+            <button
+              onClick={openCompose}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg"
+            >
+              Start a conversation
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {groupedMessages.map((thread) => (
+              <button
+                key={thread.latest.id}
+                onClick={() => openThreadPreview(thread.latest)}
+                className="w-full p-3 border rounded-lg text-left hover:bg-gray-50"
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <div>
+                    <p className="font-medium text-gray-900">
+                      {thread.patientName}
+                    </p>
+                    <p className="text-sm text-gray-700">
+                      {thread.latest.subject}
+                    </p>
+                    <p className="text-sm text-gray-500 line-clamp-1">
+                      {thread.latest.body}
+                    </p>
+                  </div>
+                  <div className="text-right">
+                    {thread.unread > 0 && (
+                      <span className="inline-flex items-center justify-center min-w-5 h-5 px-1 text-xs font-semibold rounded-full bg-blue-600 text-white">
+                        {thread.unread}
+                      </span>
+                    )}
+                    <p className="text-xs text-gray-400 mt-1">
+                      {new Date(thread.latest.created_at).toLocaleDateString()}
+                    </p>
+                  </div>
+                </div>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PatientMessagesPanel;

--- a/src/features/patient-portal/PatientLogin.tsx
+++ b/src/features/patient-portal/PatientLogin.tsx
@@ -9,25 +9,18 @@ import { loginPatientPortal } from "@/services/patientPortalAuth";
 import { isSupabaseEnabled } from "@/lib/supabaseClient";
 
 const onlineSchema = z.object({
-  email:    z.string().email("Please enter a valid email address"),
-  password: z.string().min(6, "Password must be at least 6 characters"),
-});
-
-const offlineSchema = z.object({
-  email:    z.string().email("Please enter a valid email address"),
-  password: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Please use the format YYYY-MM-DD"),
-});
-
-type LoginForm = z.infer<typeof onlineSchema>;
-  email:      z.string().email("Please enter a valid email address"),
+  email: z.string().email("Please enter a valid email address"),
   credential: z.string().min(6, "Password must be at least 6 characters"),
 });
 
 const offlineSchema = z.object({
-  email:      z.string().email("Please enter a valid email address"),
+  email: z.string().email("Please enter a valid email address"),
   credential: z
     .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/, "Please enter your date of birth as YYYY-MM-DD (e.g. 1990-01-15)"),
+    .regex(
+      /^[0-9]{4}-[0-9]{2}-[0-9]{2}$/,
+      "Please enter your date of birth as YYYY-MM-DD (e.g. 1990-01-15)",
+    ),
 });
 
 const schema = isSupabaseEnabled ? onlineSchema : offlineSchema;
@@ -37,11 +30,9 @@ export function PatientLogin() {
   const navigate = useNavigate();
   const { login } = useAuth();
   const [loading, setLoading] = useState(false);
-  const [error, setError]     = useState("");
+  const [error, setError] = useState("");
 
   const form = useForm<LoginForm>({
-    resolver: zodResolver(isSupabaseEnabled ? onlineSchema : offlineSchema),
-    defaultValues: { email: "", password: "" },
     resolver: zodResolver(schema),
     defaultValues: { email: "", credential: "" },
   });
@@ -50,12 +41,19 @@ export function PatientLogin() {
     const authError = await login(data.email, data.credential);
     if (authError) {
       const msg = authError.message.toLowerCase();
-      if (msg.includes("invalid login") || msg.includes("invalid credentials")) {
+      if (
+        msg.includes("invalid login") ||
+        msg.includes("invalid credentials")
+      ) {
         setError("Email or password is incorrect. Please try again.");
       } else if (msg.includes("email not confirmed")) {
-        setError("Please check your email and confirm your account before logging in.");
+        setError(
+          "Please check your email and confirm your account before logging in.",
+        );
       } else if (msg.includes("too many requests")) {
-        setError("Too many login attempts. Please wait a moment and try again.");
+        setError(
+          "Too many login attempts. Please wait a moment and try again.",
+        );
       } else {
         setError(authError.message);
       }
@@ -65,11 +63,17 @@ export function PatientLogin() {
   };
 
   const handleOfflineLogin = async (data: LoginForm) => {
-    const result = await loginPatientPortal(data.email, data.password, "dob").catch(() => null);
-    const result = await loginPatientPortal(data.email, data.credential, "dob").catch(() => null);
+    const result = await loginPatientPortal(
+      data.email,
+      data.credential,
+      "dob",
+    ).catch(() => null);
     if (result?.success && result.sessionToken) {
       localStorage.setItem("patient_session_token", result.sessionToken);
-      localStorage.setItem("patient_portal_user", JSON.stringify(result.portalUser));
+      localStorage.setItem(
+        "patient_portal_user",
+        JSON.stringify(result.portalUser),
+      );
       navigate("/patient/dashboard");
     } else {
       setError(result?.error || "No account found. Please register first.");
@@ -100,7 +104,9 @@ export function PatientLogin() {
             <div className="inline-flex items-center justify-center w-16 h-16 bg-blue-100 rounded-full mb-4">
               <ShieldCheckIcon className="w-8 h-8 text-blue-600" />
             </div>
-            <h1 className="text-2xl font-bold text-gray-900 mb-2">Patient Portal Login</h1>
+            <h1 className="text-2xl font-bold text-gray-900 mb-2">
+              Patient Portal Login
+            </h1>
             <p className="text-gray-600">
               {isSupabaseEnabled
                 ? "Sign in with your email and password."
@@ -110,14 +116,13 @@ export function PatientLogin() {
 
           {!isSupabaseEnabled && (
             <div className="mb-6 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-              <p className="text-xs text-yellow-800 font-medium mb-1">Running in offline mode</p>
-              <p className="text-xs text-yellow-800">
+              <p className="text-xs text-yellow-800 font-medium mb-1">
+                Running in offline mode
+              </p>
+              <p className="text-xs text-yellow-700">
                 Data is stored on this device only. Email invitations are not
                 available without an internet connection — register directly
                 using the link below.
-              <p className="text-xs text-yellow-700">
-                Data is stored on this device only. Email invitations are not available without an
-                internet connection — register directly using the link below.
               </p>
             </div>
           )}
@@ -128,9 +133,15 @@ export function PatientLogin() {
             </div>
           )}
 
-          <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-5">
+          <form
+            onSubmit={form.handleSubmit(handleSubmit)}
+            className="space-y-5"
+          >
             <div>
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-gray-700 mb-2"
+              >
                 Email Address
               </label>
               <input
@@ -143,20 +154,17 @@ export function PatientLogin() {
                 autoComplete="email"
               />
               {form.formState.errors.email && (
-                <p className="mt-2 text-sm text-red-600">{form.formState.errors.email.message}</p>
+                <p className="mt-2 text-sm text-red-600">
+                  {form.formState.errors.email.message}
+                </p>
               )}
             </div>
 
             <div>
-              <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-2">
-                {isSupabaseEnabled ? "Password" : "Date of Birth"}
-              </label>
-              <input
-                {...form.register("password")}
-                type={isSupabaseEnabled ? "password" : "date"}
-                id="password"
-                placeholder={isSupabaseEnabled ? "Your password" : ""}
-              <label htmlFor="credential" className="block text-sm font-medium text-gray-700 mb-2">
+              <label
+                htmlFor="credential"
+                className="block text-sm font-medium text-gray-700 mb-2"
+              >
                 {isSupabaseEnabled ? "Password" : "Date of Birth"}
               </label>
               <input
@@ -170,13 +178,14 @@ export function PatientLogin() {
               />
               {!isSupabaseEnabled && (
                 <p className="mt-1 text-xs text-gray-500">
-                  Use the same date of birth you entered when you registered (e.g. 1990-01-15)
+                  Use the same date of birth you entered when you registered
+                  (e.g. 1990-01-15)
                 </p>
               )}
-              {form.formState.errors.password && (
-                <p className="mt-2 text-sm text-red-600">{form.formState.errors.password.message}</p>
               {form.formState.errors.credential && (
-                <p className="mt-2 text-sm text-red-600">{form.formState.errors.credential.message}</p>
+                <p className="mt-2 text-sm text-red-600">
+                  {form.formState.errors.credential.message}
+                </p>
               )}
             </div>
 
@@ -221,7 +230,9 @@ export function PatientLogin() {
           >
             Back to Home
           </button>
-          <p className="text-sm text-gray-500">Med Bridge Health Reach · Secure patient portal</p>
+          <p className="text-sm text-gray-500">
+            Med Bridge Health Reach · Secure patient portal
+          </p>
         </div>
       </div>
     </div>

--- a/src/features/patient-portal/SecureMessaging.tsx
+++ b/src/features/patient-portal/SecureMessaging.tsx
@@ -36,6 +36,7 @@ export function SecureMessaging() {
   const [success, setSuccess] = useState("");
   const [showCompose, setShowCompose] = useState(false);
   const [selectedMessage, setSelectedMessage] = useState<Message | null>(null);
+  const [replyStaffId, setReplyStaffId] = useState<string | null>(null);
   const [newMessage, setNewMessage] = useState({ subject: "", body: "" });
   const isOffline = !supabase;
 
@@ -158,6 +159,7 @@ export function SecureMessaging() {
         .from("patient_secure_messages")
         .insert({
           patient_id: portalUser.patientId,
+          staff_id: replyStaffId,
           subject: newMessage.subject,
           body: newMessage.body,
           from_patient: true,
@@ -170,6 +172,7 @@ export function SecureMessaging() {
       setSuccess("Message sent successfully");
       setNewMessage({ subject: "", body: "" });
       setShowCompose(false);
+      setReplyStaffId(null);
       await loadMessages();
     } catch (err) {
       logger.error("Error sending message:", err);
@@ -200,6 +203,18 @@ export function SecureMessaging() {
     }
   };
 
+  const handleReply = () => {
+    if (!selectedMessage) return;
+    setReplyStaffId(selectedMessage.staff_id || null);
+    setNewMessage({
+      subject: selectedMessage.subject.startsWith("Re:")
+        ? selectedMessage.subject
+        : `Re: ${selectedMessage.subject}`,
+      body: "",
+    });
+    setShowCompose(true);
+  };
+
   if (loading) {
     return (
       <div className="min-h-screen bg-gray-50 px-4 py-8">
@@ -226,7 +241,10 @@ export function SecureMessaging() {
             </p>
           </div>
           <button
-            onClick={() => setShowCompose(true)}
+            onClick={() => {
+              setReplyStaffId(null);
+              setShowCompose(true);
+            }}
             className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
           >
             New Message
@@ -237,7 +255,8 @@ export function SecureMessaging() {
           <div className="mb-4 p-4 bg-amber-50 border border-amber-200 rounded-lg flex items-center gap-3">
             <WifiIcon className="w-5 h-5 text-amber-600 flex-shrink-0" />
             <p className="text-sm text-amber-800">
-              Offline mode — messages will sync when you connect to the internet.
+              Offline mode — messages will sync when you connect to the
+              internet.
             </p>
           </div>
         )}
@@ -329,12 +348,22 @@ export function SecureMessaging() {
 
         {selectedMessage ? (
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-            <button
-              onClick={() => setSelectedMessage(null)}
-              className="mb-4 text-blue-600 hover:text-blue-800"
-            >
-              ← Back to inbox
-            </button>
+            <div className="mb-4 flex items-center justify-between">
+              <button
+                onClick={() => setSelectedMessage(null)}
+                className="text-blue-600 hover:text-blue-800"
+              >
+                ← Back to inbox
+              </button>
+              {!selectedMessage.from_patient && (
+                <button
+                  onClick={handleReply}
+                  className="px-3 py-1.5 bg-blue-600 text-white rounded-md hover:bg-blue-700"
+                >
+                  Reply
+                </button>
+              )}
+            </div>
 
             <div className="border-b border-gray-200 pb-4 mb-4">
               <h2 className="text-xl font-semibold text-gray-900">

--- a/src/pages/DoctorDashboard.tsx
+++ b/src/pages/DoctorDashboard.tsx
@@ -5,8 +5,8 @@ import type { Patient, Visit, Vital, QueueItem } from "@/db";
 import { useAuthStore } from "@/stores/auth";
 import { queueManagement } from "@/services/queueManagement";
 import { getFlagColor } from "@/utils/vitals";
-import { palaverRoom } from "@/services/palaverRoom";
-import { PalaverRoom } from "@/features/doctor/PalaverRoom";
+import { getDoctorUnreadCount } from "@/services/patientSecureMessaging";
+import { PatientMessagesPanel } from "@/features/doctor/PatientMessagesPanel";
 import {
   UserIcon,
   ClockIcon,
@@ -33,15 +33,13 @@ export function DoctorDashboard() {
   const [loading, setLoading] = useState(true);
   const [showPalaverRoom, setShowPalaverRoom] = useState(false);
   const [unreadMessages, setUnreadMessages] = useState(0);
-  const [initialLoadDone, setInitialLoadDone] = useState(false);
 
   const userId = currentUser?.id;
 
   const loadUnreadCount = useCallback(async () => {
     if (!userId) return;
     try {
-      if (!palaverRoom.isAvailable()) return;
-      const count = await palaverRoom.getUnreadCount(userId);
+      const count = await getDoctorUnreadCount(userId);
       setUnreadMessages(count);
     } catch (err) {
       console.error("Failed to load unread count:", err);
@@ -116,7 +114,6 @@ export function DoctorDashboard() {
       } finally {
         if (isInitial) {
           setLoading(false);
-          setInitialLoadDone(true);
         }
       }
     },
@@ -203,13 +200,13 @@ export function DoctorDashboard() {
           </p>
         </div>
         <div className="flex items-center gap-4">
-          {/* Palaver Room Button */}
+          {/* Patient Messages Button */}
           <button
             onClick={() => setShowPalaverRoom(true)}
             className="relative flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors shadow-sm"
           >
             <ChatBubbleLeftRightIcon className="h-5 w-5" />
-            <span className="font-medium">Palaver Room</span>
+            <span className="font-medium">Patient Messages</span>
             {unreadMessages > 0 && (
               <span className="absolute -top-2 -right-2 px-2 py-0.5 bg-red-500 text-white text-xs font-bold rounded-full min-w-[20px] text-center">
                 {unreadMessages}
@@ -241,7 +238,7 @@ export function DoctorDashboard() {
         </div>
       </div>
 
-      {/* Palaver Room Sliding Panel */}
+      {/* Patient Messages Sliding Panel */}
       {showPalaverRoom && (
         <>
           <div
@@ -249,12 +246,12 @@ export function DoctorDashboard() {
             onClick={() => setShowPalaverRoom(false)}
           />
           <div className="fixed right-0 top-0 bottom-0 w-full max-w-md z-50 shadow-2xl">
-            <PalaverRoom
+            <PatientMessagesPanel
               onClose={() => {
                 setShowPalaverRoom(false);
                 loadUnreadCount();
               }}
-              isPanel={true}
+              onUnreadChange={setUnreadMessages}
             />
           </div>
         </>
@@ -481,7 +478,7 @@ export function DoctorDashboard() {
             className="relative btn-secondary flex flex-col items-center justify-center p-4 h-24 bg-emerald-50 border-emerald-200 hover:bg-emerald-100"
           >
             <ChatBubbleLeftRightIcon className="h-6 w-6 mb-2 text-emerald-600" />
-            <span className="text-sm text-emerald-800">Palaver Room</span>
+            <span className="text-sm text-emerald-800">Patient Messages</span>
             {unreadMessages > 0 && (
               <span className="absolute top-2 right-2 px-1.5 py-0.5 bg-red-500 text-white text-xs font-bold rounded-full">
                 {unreadMessages}

--- a/src/pages/admin/ConflictDashboard.tsx
+++ b/src/pages/admin/ConflictDashboard.tsx
@@ -168,10 +168,6 @@ export default function ConflictDashboard() {
         id: `duplicate-scan-${Date.now()}`,
         title: "Duplicate scan complete",
         body: `Found ${result.found} new potential duplicate${result.found !== 1 ? "s" : ""}.${skippedMessage}`,
-      pushToast({
-        id: `duplicate-scan-${Date.now()}`,
-        title: "Duplicate scan complete",
-        body: `Found ${found} new potential duplicate${found !== 1 ? "s" : ""}.`,
       });
     } catch (error) {
       console.error("Scan failed:", error);

--- a/src/services/conflictQueue.ts
+++ b/src/services/conflictQueue.ts
@@ -793,18 +793,6 @@ export class ConflictQueueService {
           dob,
           address: patient.address,
         });
-    for (const [index, patient] of patients.entries()) {
-      const candidates = await patientDeduplication.findDuplicates({
-        givenName: patient.givenName,
-        familyName: patient.familyName,
-        phone: patient.phone || undefined,
-        dob: new Date(patient.dob),
-        address: patient.address,
-      });
-
-      const otherCandidates = candidates.filter(
-        (c) => c.patient.id !== patient.id,
-      );
 
         const otherCandidates = candidates.filter(
           (c) => c.patient.id !== patient.id,
@@ -838,13 +826,6 @@ export class ConflictQueueService {
         logger.warn("Skipping patient during duplicate scan", {
           patientId: patient.id,
           error,
-        });
-      }
-
-      // Yield periodically so large scans don't block the UI thread and hurt INP.
-      if ((index + 1) % 10 === 0) {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 0);
         });
       }
 

--- a/src/services/patientSecureMessaging.ts
+++ b/src/services/patientSecureMessaging.ts
@@ -1,0 +1,163 @@
+import { supabase } from "@/lib/supabase";
+
+export interface PatientSecureMessage {
+  id: string;
+  patient_id: string;
+  staff_id: string | null;
+  subject: string;
+  body: string;
+  from_patient: boolean;
+  from_name: string;
+  read: boolean;
+  created_at: string;
+}
+
+export interface PatientSearchResult {
+  id: string;
+  fullName: string;
+}
+
+async function loadPatientNameMap(patientIds: string[]) {
+  if (!supabase || patientIds.length === 0) return new Map<string, string>();
+
+  const uniqueIds = Array.from(new Set(patientIds));
+
+  const map = new Map<string, string>();
+
+  const snake = await supabase
+    .from("patients")
+    .select("id,given_name,family_name")
+    .in("id", uniqueIds);
+
+  if (!snake.error && snake.data) {
+    snake.data.forEach((p) => {
+      map.set(
+        p.id as string,
+        `${(p.given_name as string) || ""} ${(p.family_name as string) || ""}`.trim(),
+      );
+    });
+    return map;
+  }
+
+  const camel = await supabase
+    .from("patients")
+    .select("id,givenName,familyName")
+    .in("id", uniqueIds);
+
+  if (!camel.error && camel.data) {
+    camel.data.forEach((p) => {
+      map.set(
+        p.id as string,
+        `${(p.givenName as string) || ""} ${(p.familyName as string) || ""}`.trim(),
+      );
+    });
+  }
+
+  return map;
+}
+
+export async function getDoctorMessageInbox(staffId: string): Promise<{
+  messages: PatientSecureMessage[];
+  patientNames: Map<string, string>;
+}> {
+  if (!supabase) return { messages: [], patientNames: new Map() };
+
+  const { data, error } = await supabase
+    .from("patient_secure_messages")
+    .select("*")
+    .or(`staff_id.eq.${staffId},and(staff_id.is.null,from_patient.eq.true)`)
+    .order("created_at", { ascending: false });
+
+  if (error) throw error;
+
+  const messages = (data || []) as PatientSecureMessage[];
+  const patientNames = await loadPatientNameMap(
+    messages.map((m) => m.patient_id),
+  );
+
+  return { messages, patientNames };
+}
+
+export async function getDoctorUnreadCount(staffId: string): Promise<number> {
+  if (!supabase) return 0;
+
+  const { count, error } = await supabase
+    .from("patient_secure_messages")
+    .select("id", { count: "exact", head: true })
+    .eq("from_patient", true)
+    .eq("read", false)
+    .or(`staff_id.eq.${staffId},staff_id.is.null`);
+
+  if (error) throw error;
+  return count || 0;
+}
+
+export async function searchPatientsByName(
+  query: string,
+): Promise<PatientSearchResult[]> {
+  if (!supabase || query.trim().length < 2) return [];
+
+  const term = `%${query.trim()}%`;
+
+  const snake = await supabase
+    .from("patients")
+    .select("id,given_name,family_name")
+    .or(`given_name.ilike.${term},family_name.ilike.${term}`)
+    .limit(8);
+
+  if (!snake.error && snake.data) {
+    return snake.data.map((p) => ({
+      id: p.id as string,
+      fullName:
+        `${(p.given_name as string) || ""} ${(p.family_name as string) || ""}`.trim(),
+    }));
+  }
+
+  const camel = await supabase
+    .from("patients")
+    .select("id,givenName,familyName")
+    .or(`givenName.ilike.${term},familyName.ilike.${term}`)
+    .limit(8);
+
+  if (camel.error) throw camel.error;
+
+  return (camel.data || []).map((p) => ({
+    id: p.id as string,
+    fullName:
+      `${(p.givenName as string) || ""} ${(p.familyName as string) || ""}`.trim(),
+  }));
+}
+
+export async function sendDoctorMessage(params: {
+  staffId: string;
+  staffName: string;
+  patientId: string;
+  subject: string;
+  body: string;
+}) {
+  if (!supabase) {
+    throw new Error("Secure messaging is unavailable while offline.");
+  }
+
+  const { error } = await supabase.from("patient_secure_messages").insert({
+    patient_id: params.patientId,
+    staff_id: params.staffId,
+    subject: params.subject.trim(),
+    body: params.body.trim(),
+    from_patient: false,
+    from_name: params.staffName,
+    read: false,
+  });
+
+  if (error) throw error;
+}
+
+export async function markMessageRead(messageId: string) {
+  if (!supabase) return;
+  const { error } = await supabase
+    .from("patient_secure_messages")
+    .update({ read: true })
+    .eq("id", messageId);
+
+  if (error) throw error;
+}


### PR DESCRIPTION
### Motivation
- Provide doctors with an inbox/compose UI to message patients and surface unread counts in the dashboard. 
- Reuse and centralize Supabase logic for doctor↔patient secure messages. 
- Improve patient portal messaging UX by allowing replies to staff messages and unify patient login credential handling.

### Description
- Added a new Supabase-backed service `src/services/patientSecureMessaging.ts` exporting typed helpers: `getDoctorMessageInbox`, `getDoctorUnreadCount`, `searchPatientsByName`, `sendDoctorMessage`, and `markMessageRead`, plus helper for loading patient name map. 
- Introduced a new UI component `src/features/doctor/PatientMessagesPanel.tsx` that implements an inbox, message grouping by patient, compose flow with patient search, read marking, and sends via the new service. 
- Integrated the messages panel into `src/pages/DoctorDashboard.tsx`, replacing the previous PalaverRoom usage with a `Patient Messages` sliding panel and wiring unread counts via `getDoctorUnreadCount`. 
- Updated patient-side messaging in `src/features/patient-portal/SecureMessaging.tsx` to support replying to staff messages by storing `staff_id` on send, adding a `Reply` button, and ensuring new messages include `staff_id` when appropriate. 
- Refactored patient login in `src/features/patient-portal/PatientLogin.tsx` to unify the credential field name, update Zod schemas and validation messages, and perform small markup/spacing cleanups. 
- Fixed logic and cleanup in conflict scanning and duplicate detection by removing duplicated loops and deduplicating yield logic in `src/services/conflictQueue.ts`, and removed a duplicated `pushToast` in `src/pages/admin/ConflictDashboard.tsx`.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53b7b83448332be067eb51271b867)