### PR TITLE
Fix Vite env fallback and idempotent dispenses policy in migration

### DIFF
--- a/supabase/migrations/20250930065243_empty_band.sql
+++ b/supabase/migrations/20250930065243_empty_band.sql
@@ -168,12 +168,24 @@ create table if not exists dispenses (
 );
 
 alter table dispenses enable row level security;
-create policy "Allow authenticated access to dispenses"
-  on dispenses
-  for all
-  to authenticated
-  using (true)
-  with check (true);
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'dispenses'
+      and policyname = 'Allow authenticated access to dispenses'
+  ) then
+    create policy "Allow authenticated access to dispenses"
+      on dispenses
+      for all
+      to authenticated
+      using (true)
+      with check (true);
+  end if;
+end
+$$;
 
 create table if not exists stock_moves_rx (
   id text primary key,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,139 +1,147 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import { resolve } from "path";
 
-const clientSupabaseUrl =
-  process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL || "";
-const clientSupabaseAnonKey =
-  process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY || "";
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const define: Record<string, string> = {};
 
-export default defineConfig({
-  define: {
-    "import.meta.env.VITE_SUPABASE_URL": JSON.stringify(clientSupabaseUrl),
-    "import.meta.env.VITE_SUPABASE_ANON_KEY": JSON.stringify(
-      clientSupabaseAnonKey,
-    ),
-  },
-  resolve: {
-    alias: {
-      "@": resolve(__dirname, "./src"),
+  if (!env.VITE_SUPABASE_URL && env.SUPABASE_URL) {
+    define["import.meta.env.VITE_SUPABASE_URL"] = JSON.stringify(
+      env.SUPABASE_URL,
+    );
+  }
+
+  if (!env.VITE_SUPABASE_ANON_KEY && env.SUPABASE_ANON_KEY) {
+    define["import.meta.env.VITE_SUPABASE_ANON_KEY"] = JSON.stringify(
+      env.SUPABASE_ANON_KEY,
+    );
+  }
+
+  return {
+    define,
+    resolve: {
+      alias: {
+        "@": resolve(__dirname, "./src"),
+      },
     },
-  },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: (id) => {
-          if (id.includes("node_modules")) {
-            if (
-              id.includes("react") ||
-              id.includes("react-dom") ||
-              id.includes("react-router")
-            ) {
-              return "react-vendor";
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: (id) => {
+            if (id.includes("node_modules")) {
+              if (
+                id.includes("react") ||
+                id.includes("react-dom") ||
+                id.includes("react-router")
+              ) {
+                return "react-vendor";
+              }
+              if (
+                id.includes("react-hook-form") ||
+                id.includes("zod") ||
+                id.includes("@hookform")
+              ) {
+                return "form-vendor";
+              }
+              if (id.includes("@headlessui") || id.includes("@heroicons")) {
+                return "ui-vendor";
+              }
+              if (id.includes("dexie") || id.includes("idb-keyval")) {
+                return "db-vendor";
+              }
+              if (id.includes("i18next")) {
+                return "i18n-vendor";
+              }
+              if (id.includes("zustand")) {
+                return "state-vendor";
+              }
+              if (id.includes("@supabase")) {
+                return "supabase-vendor";
+              }
+              if (id.includes("@sentry")) {
+                return "sentry-vendor";
+              }
             }
-            if (
-              id.includes("react-hook-form") ||
-              id.includes("zod") ||
-              id.includes("@hookform")
-            ) {
-              return "form-vendor";
-            }
-            if (id.includes("@headlessui") || id.includes("@heroicons")) {
-              return "ui-vendor";
-            }
-            if (id.includes("dexie") || id.includes("idb-keyval")) {
-              return "db-vendor";
-            }
-            if (id.includes("i18next")) {
-              return "i18n-vendor";
-            }
-            if (id.includes("zustand")) {
-              return "state-vendor";
-            }
-            if (id.includes("@supabase")) {
-              return "supabase-vendor";
-            }
-            if (id.includes("@sentry")) {
-              return "sentry-vendor";
-            }
-          }
 
-          if (id.includes("/features/gamification/")) {
-            return "gamification";
-          }
-          if (id.includes("/features/analytics/")) {
-            return "analytics";
-          }
-          if (id.includes("/features/pharmacy/")) {
-            return "pharmacy";
-          }
-          if (id.includes("/features/patient-portal/")) {
-            return "patient-portal";
-          }
-          if (id.includes("/features/tickets/")) {
-            return "tickets";
-          }
-          if (id.includes("/features/labs/")) {
-            return "labs";
-          }
-          if (id.includes("/features/triage/")) {
-            return "triage";
-          }
-          if (id.includes("/features/vitals/")) {
-            return "vitals";
-          }
-          if (id.includes("/pages/admin/")) {
-            return "admin";
-          }
-          if (id.includes("/i18n/locales/")) {
-            const lang = id.match(/locales\/(\w+)\.json/)?.[1];
-            if (lang) return lang;
-          }
+            if (id.includes("/features/gamification/")) {
+              return "gamification";
+            }
+            if (id.includes("/features/analytics/")) {
+              return "analytics";
+            }
+            if (id.includes("/features/pharmacy/")) {
+              return "pharmacy";
+            }
+            if (id.includes("/features/patient-portal/")) {
+              return "patient-portal";
+            }
+            if (id.includes("/features/tickets/")) {
+              return "tickets";
+            }
+            if (id.includes("/features/labs/")) {
+              return "labs";
+            }
+            if (id.includes("/features/triage/")) {
+              return "triage";
+            }
+            if (id.includes("/features/vitals/")) {
+              return "vitals";
+            }
+            if (id.includes("/pages/admin/")) {
+              return "admin";
+            }
+            if (id.includes("/i18n/locales/")) {
+              const lang = id.match(/locales\/(\w+)\.json/)?.[1];
+              if (lang) return lang;
+            }
+          },
+        },
+      },
+      chunkSizeWarningLimit: 1000,
+      target: "es2020",
+      minify: "terser",
+      terserOptions: {
+        compress: {
+          drop_console: process.env.NODE_ENV === "production",
+          drop_debugger: true,
+          pure_funcs:
+            process.env.NODE_ENV === "production"
+              ? ["console.log", "console.info"]
+              : [],
         },
       },
     },
-    chunkSizeWarningLimit: 1000,
-    target: "es2020",
-    minify: "terser",
-    terserOptions: {
-      compress: {
-        drop_console: process.env.NODE_ENV === "production",
-        drop_debugger: true,
-        pure_funcs:
-          process.env.NODE_ENV === "production"
-            ? ["console.log", "console.info"]
-            : [],
-      },
+    esbuild: {
+      drop:
+        process.env.NODE_ENV === "production" ? ["console", "debugger"] : [],
     },
-  },
-  esbuild: {
-    drop: process.env.NODE_ENV === "production" ? ["console", "debugger"] : [],
-  },
-  plugins: [
-    react(),
-    VitePWA({
-      registerType: "autoUpdate",
-      workbox: {
-        globPatterns: ["**/*.{js,css,html,ico,png,svg,mp3}"],
-        maximumFileSizeToCacheInBytes: 3000000,
-      },
-      manifest: {
-        name: "Med Bridge Health Reach",
-        short_name: "MBHR",
-        description: "Offline-first medical outreach platform",
-        theme_color: "#0A7A3B",
-        icons: [
-          { src: "pwa-192x192.png", sizes: "192x192", type: "image/png" },
-          { src: "pwa-512x512.png", sizes: "512x512", type: "image/png" },
-          {
-            src: "pwa-512x512-maskable.png",
-            sizes: "512x512",
-            type: "image/png",
-            purpose: "maskable",
-          },
-        ],
-      },
-    }),
-  ],
+    plugins: [
+      react(),
+      VitePWA({
+        registerType: "autoUpdate",
+        workbox: {
+          globPatterns: ["**/*.{js,css,html,ico,png,svg,mp3}"],
+          maximumFileSizeToCacheInBytes: 3000000,
+        },
+        manifest: {
+          name: "Med Bridge Health Reach",
+          short_name: "MBHR",
+          description: "Offline-first medical outreach platform",
+          theme_color: "#0A7A3B",
+          icons: [
+            { src: "pwa-192x192.png", sizes: "192x192", type: "image/png" },
+            { src: "pwa-512x512.png", sizes: "512x512", type: "image/png" },
+            {
+              src: "pwa-512x512-maskable.png",
+              sizes: "512x512",
+              type: "image/png",
+              purpose: "maskable",
+            },
+          ],
+        },
+      }),
+    ],
+  };
 });


### PR DESCRIPTION
### Motivation

- Prevent build-time replacement of `import.meta.env.VITE_SUPABASE_*` with empty strings when `.env` values are loaded via Vite, which caused the client to report Supabase as unconfigured.
- Prevent ordered-migration failures caused by recreating an already-existing `dispenses` policy, which aborts the migration chain on duplicate-policy errors.

### Description

- Updated `vite.config.ts` to import and use `loadEnv(mode, process.cwd(), "")` and to only add `define` mappings for `import.meta.env.VITE_SUPABASE_URL` and `import.meta.env.VITE_SUPABASE_ANON_KEY` when the `VITE_*` variables are missing but `SUPABASE_*` are present, avoiding unconditional empty-string overrides.
- Replaced the unconditional `CREATE POLICY` for `dispenses` in `supabase/migrations/20250930065243_empty_band.sql` with a `DO $$ ... $$` block that checks `pg_policies` and only creates the policy if it does not already exist, making the migration idempotent.
- Made small structural/formatting updates around the `define` and build config in `vite.config.ts` to return a Vite config factory function that respects `mode`-scoped env values.

### Testing

- Ran `npm run typecheck` which completed successfully (no TypeScript errors).
- Ran `npm run build` which completed successfully (Vite production build finished without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e56e8f82f883328e2b323f2ec6472f)