### PR TITLE
Fix duplicate-scan to surface operational failures in conflict queue

### DIFF
--- a/src/services/conflictQueue.ts
+++ b/src/services/conflictQueue.ts
@@ -778,27 +778,24 @@ export class ConflictQueueService {
     let skippedRecords = 0;
 
     for (const [index, patient] of patients.entries()) {
-      try {
-        const dob = new Date(patient.dob);
-        const hasValidDob = Number.isFinite(dob.getTime());
-        if (!hasValidDob || !patient.givenName || !patient.familyName) {
-          skippedRecords++;
-          continue;
-        }
-
-        const candidates = await patientDeduplication.findDuplicates({
-          givenName: patient.givenName,
-          familyName: patient.familyName,
-          phone: patient.phone || undefined,
-          dob,
-          address: patient.address,
+      const dob = new Date(patient.dob);
+      const hasValidDob = Number.isFinite(dob.getTime());
+      if (!hasValidDob || !patient.givenName || !patient.familyName) {
+        skippedRecords++;
+        logger.warn("Skipping patient with invalid duplicate-scan data", {
+          patientId: patient.id,
+          hasValidDob,
+          hasGivenName: Boolean(patient.givenName),
+          hasFamilyName: Boolean(patient.familyName),
         });
-    for (const patient of patients) {
+        continue;
+      }
+
       const candidates = await patientDeduplication.findDuplicates({
         givenName: patient.givenName,
         familyName: patient.familyName,
         phone: patient.phone || undefined,
-        dob: new Date(patient.dob),
+        dob,
         address: patient.address,
       });
 
@@ -806,39 +803,28 @@ export class ConflictQueueService {
         (c) => c.patient.id !== patient.id,
       );
 
-        const otherCandidates = candidates.filter(
-          (c) => c.patient.id !== patient.id,
+      if (otherCandidates.length > 0) {
+        const existing = await this.checkExistingConflict(
+          patient.id,
+          "duplicate",
         );
-
-        if (otherCandidates.length > 0) {
-          const existing = await this.checkExistingConflict(
-            patient.id,
-            "duplicate",
-          );
-          if (!existing) {
-            await this.createConflict({
-              conflictType: "duplicate",
-              entityType: "patients",
-              entityId: patient.id,
-              candidateIds: otherCandidates.map((c) => c.patient.id),
-              conflictDetails: {
-                fields: this.buildDuplicateFields(
-                  patient,
-                  otherCandidates[0].patient,
-                ),
-                matchScore: otherCandidates[0].score,
-                matchReasons: otherCandidates[0].matchReasons,
-              },
-            });
-            duplicatesFound++;
-          }
+        if (!existing) {
+          await this.createConflict({
+            conflictType: "duplicate",
+            entityType: "patients",
+            entityId: patient.id,
+            candidateIds: otherCandidates.map((c) => c.patient.id),
+            conflictDetails: {
+              fields: this.buildDuplicateFields(
+                patient,
+                otherCandidates[0].patient,
+              ),
+              matchScore: otherCandidates[0].score,
+              matchReasons: otherCandidates[0].matchReasons,
+            },
+          });
+          duplicatesFound++;
         }
-      } catch (error) {
-        skippedRecords++;
-        logger.warn("Skipping patient during duplicate scan", {
-          patientId: patient.id,
-          error,
-        });
       }
 
       // Yield periodically so large scans don't block the UI thread and hurt INP.


### PR DESCRIPTION
### Motivation
- Prevent transient/runtime failures in duplicate detection or conflict persistence from being misclassified as "skipped" records so scans don't falsely report success. 
- Only intentionally skip records with invalid patient data (e.g., bad DOB or missing names) while letting operational errors bubble up so the dashboard can surface real failures.

### Description
- Reworked `scanForDuplicates` in `src/services/conflictQueue.ts` to remove the broad catch that previously converted all runtime errors into `skipped` counts. 
- Added explicit record validation (DOB / givenName / familyName) that increments `skipped` and emits a structured `logger.warn` when data is invalid. 
- Left calls to `patientDeduplication.findDuplicates`, `checkExistingConflict`, and `createConflict` unwrapped so operational/database errors propagate to callers. 
- Preserved periodic yielding (`setTimeout(..., 0)` every 10 records) to keep large scans responsive and retained the original `{ found, skipped }` return shape.

### Testing
- `npx tsc-files --noEmit src/services/conflictQueue.ts` was run and completed successfully for the modified file. 
- A full repo typecheck via `npm run typecheck` was attempted but failed due to pre-existing unrelated JSX/TSX syntax errors in other files (`PatientMessagesPanel.tsx` and `PatientLogin.tsx`), so full-project typechecking could not be completed here. 
- No behavioral/unit tests were changed; the change is limited to error-handling semantics in the duplicate-scan flow and validated with the file-level type check above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5700aef6883328d85d10364f338d1)