### PR TITLE
Fix Vite Supabase env mapping to load .env VITE_* values correctly

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,139 +1,139 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import { resolve } from "path";
 
-const clientSupabaseUrl =
-  process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL || "";
-const clientSupabaseAnonKey =
-  process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY || "";
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const clientSupabaseUrl = env.VITE_SUPABASE_URL || env.SUPABASE_URL || "";
+  const clientSupabaseAnonKey =
+    env.VITE_SUPABASE_ANON_KEY || env.SUPABASE_ANON_KEY || "";
 
-export default defineConfig({
-  define: {
-    "import.meta.env.VITE_SUPABASE_URL": JSON.stringify(clientSupabaseUrl),
-    "import.meta.env.VITE_SUPABASE_ANON_KEY": JSON.stringify(
-      clientSupabaseAnonKey,
-    ),
-  },
-  resolve: {
-    alias: {
-      "@": resolve(__dirname, "./src"),
+  return {
+    define: {
+      "import.meta.env.VITE_SUPABASE_URL": JSON.stringify(clientSupabaseUrl),
+      "import.meta.env.VITE_SUPABASE_ANON_KEY": JSON.stringify(
+        clientSupabaseAnonKey,
+      ),
     },
-  },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: (id) => {
-          if (id.includes("node_modules")) {
-            if (
-              id.includes("react") ||
-              id.includes("react-dom") ||
-              id.includes("react-router")
-            ) {
-              return "react-vendor";
+    resolve: {
+      alias: {
+        "@": resolve(__dirname, "./src"),
+      },
+    },
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: (id) => {
+            if (id.includes("node_modules")) {
+              if (
+                id.includes("react") ||
+                id.includes("react-dom") ||
+                id.includes("react-router")
+              ) {
+                return "react-vendor";
+              }
+              if (
+                id.includes("react-hook-form") ||
+                id.includes("zod") ||
+                id.includes("@hookform")
+              ) {
+                return "form-vendor";
+              }
+              if (id.includes("@headlessui") || id.includes("@heroicons")) {
+                return "ui-vendor";
+              }
+              if (id.includes("dexie") || id.includes("idb-keyval")) {
+                return "db-vendor";
+              }
+              if (id.includes("i18next")) {
+                return "i18n-vendor";
+              }
+              if (id.includes("zustand")) {
+                return "state-vendor";
+              }
+              if (id.includes("@supabase")) {
+                return "supabase-vendor";
+              }
+              if (id.includes("@sentry")) {
+                return "sentry-vendor";
+              }
             }
-            if (
-              id.includes("react-hook-form") ||
-              id.includes("zod") ||
-              id.includes("@hookform")
-            ) {
-              return "form-vendor";
-            }
-            if (id.includes("@headlessui") || id.includes("@heroicons")) {
-              return "ui-vendor";
-            }
-            if (id.includes("dexie") || id.includes("idb-keyval")) {
-              return "db-vendor";
-            }
-            if (id.includes("i18next")) {
-              return "i18n-vendor";
-            }
-            if (id.includes("zustand")) {
-              return "state-vendor";
-            }
-            if (id.includes("@supabase")) {
-              return "supabase-vendor";
-            }
-            if (id.includes("@sentry")) {
-              return "sentry-vendor";
-            }
-          }
 
-          if (id.includes("/features/gamification/")) {
-            return "gamification";
-          }
-          if (id.includes("/features/analytics/")) {
-            return "analytics";
-          }
-          if (id.includes("/features/pharmacy/")) {
-            return "pharmacy";
-          }
-          if (id.includes("/features/patient-portal/")) {
-            return "patient-portal";
-          }
-          if (id.includes("/features/tickets/")) {
-            return "tickets";
-          }
-          if (id.includes("/features/labs/")) {
-            return "labs";
-          }
-          if (id.includes("/features/triage/")) {
-            return "triage";
-          }
-          if (id.includes("/features/vitals/")) {
-            return "vitals";
-          }
-          if (id.includes("/pages/admin/")) {
-            return "admin";
-          }
-          if (id.includes("/i18n/locales/")) {
-            const lang = id.match(/locales\/(\w+)\.json/)?.[1];
-            if (lang) return lang;
-          }
+            if (id.includes("/features/gamification/")) {
+              return "gamification";
+            }
+            if (id.includes("/features/analytics/")) {
+              return "analytics";
+            }
+            if (id.includes("/features/pharmacy/")) {
+              return "pharmacy";
+            }
+            if (id.includes("/features/patient-portal/")) {
+              return "patient-portal";
+            }
+            if (id.includes("/features/tickets/")) {
+              return "tickets";
+            }
+            if (id.includes("/features/labs/")) {
+              return "labs";
+            }
+            if (id.includes("/features/triage/")) {
+              return "triage";
+            }
+            if (id.includes("/features/vitals/")) {
+              return "vitals";
+            }
+            if (id.includes("/pages/admin/")) {
+              return "admin";
+            }
+            if (id.includes("/i18n/locales/")) {
+              const lang = id.match(/locales\/(\w+)\.json/)?.[1];
+              if (lang) return lang;
+            }
+          },
+        },
+      },
+      chunkSizeWarningLimit: 1000,
+      target: "es2020",
+      minify: "terser",
+      terserOptions: {
+        compress: {
+          drop_console: mode === "production",
+          drop_debugger: true,
+          pure_funcs:
+            mode === "production" ? ["console.log", "console.info"] : [],
         },
       },
     },
-    chunkSizeWarningLimit: 1000,
-    target: "es2020",
-    minify: "terser",
-    terserOptions: {
-      compress: {
-        drop_console: process.env.NODE_ENV === "production",
-        drop_debugger: true,
-        pure_funcs:
-          process.env.NODE_ENV === "production"
-            ? ["console.log", "console.info"]
-            : [],
-      },
+    esbuild: {
+      drop: mode === "production" ? ["console", "debugger"] : [],
     },
-  },
-  esbuild: {
-    drop: process.env.NODE_ENV === "production" ? ["console", "debugger"] : [],
-  },
-  plugins: [
-    react(),
-    VitePWA({
-      registerType: "autoUpdate",
-      workbox: {
-        globPatterns: ["**/*.{js,css,html,ico,png,svg,mp3}"],
-        maximumFileSizeToCacheInBytes: 3000000,
-      },
-      manifest: {
-        name: "Med Bridge Health Reach",
-        short_name: "MBHR",
-        description: "Offline-first medical outreach platform",
-        theme_color: "#0A7A3B",
-        icons: [
-          { src: "pwa-192x192.png", sizes: "192x192", type: "image/png" },
-          { src: "pwa-512x512.png", sizes: "512x512", type: "image/png" },
-          {
-            src: "pwa-512x512-maskable.png",
-            sizes: "512x512",
-            type: "image/png",
-            purpose: "maskable",
-          },
-        ],
-      },
-    }),
-  ],
+    plugins: [
+      react(),
+      VitePWA({
+        registerType: "autoUpdate",
+        workbox: {
+          globPatterns: ["**/*.{js,css,html,ico,png,svg,mp3}"],
+          maximumFileSizeToCacheInBytes: 3000000,
+        },
+        manifest: {
+          name: "Med Bridge Health Reach",
+          short_name: "MBHR",
+          description: "Offline-first medical outreach platform",
+          theme_color: "#0A7A3B",
+          icons: [
+            { src: "pwa-192x192.png", sizes: "192x192", type: "image/png" },
+            { src: "pwa-512x512.png", sizes: "512x512", type: "image/png" },
+            {
+              src: "pwa-512x512-maskable.png",
+              sizes: "512x512",
+              type: "image/png",
+              purpose: "maskable",
+            },
+          ],
+        },
+      }),
+    ],
+  };
 });


### PR DESCRIPTION
### Motivation

- Prevent `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` from being compiled to empty strings when values are provided only via `.env` by ensuring Vite's env loading is used in the config.  
- Preserve the intended fallback for `SUPABASE_*` -> `VITE_SUPABASE_*` so deployments that set plain `SUPABASE_*` still provide client values.

### Description

- Convert `vite.config.ts` to a function-based config and call `loadEnv(mode, process.cwd(), "")` to read `.env` files instead of reading `process.env` at module-time.  
- Compute `clientSupabaseUrl` / `clientSupabaseAnonKey` from `env.VITE_SUPABASE_* || env.SUPABASE_*` and inject them into `import.meta.env.VITE_SUPABASE_*` via `define`, preserving the original fallback behavior.  
- Use `mode === "production"` for production checks in the config (replaces `process.env.NODE_ENV` checks) for clarity in the function-based config.

### Testing

- Ran `npm run build` (which runs `tsc -b && vite build`) and the production build completed successfully.  
- Ran `npm run lint` and observed pre-existing repository-wide lint errors unrelated to this change (lint failed but errors are not caused by the config update).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e56fbda540833285fc8bbb0d95337d)