### PR TITLE
[PR #9 follow-up] Fix addVisit consistency when consultation insert fails

### DIFF
--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -11,7 +11,7 @@ import * as logger from "@/lib/logger";
 // ─── Domain types (camelCase for the app) ─────────────────────────────────────
 
 export interface PatientProfile {
-  id: string;           // text pk
+  id: string; // text pk
   authUid: string | null;
   givenName: string;
   familyName: string;
@@ -56,8 +56,8 @@ export interface Visit {
   startedAt: string;
   siteName: string | null;
   status: string;
-  diagnosis: string | null;    // from consultations.soap_assessment
-  notes: string | null;        // from consultations.soap_subjective
+  diagnosis: string | null; // from consultations.soap_assessment
+  notes: string | null; // from consultations.soap_subjective
 }
 
 export interface ServiceResult<T> {
@@ -69,27 +69,31 @@ export interface ServiceResult<T> {
 
 function rowToProfile(r: Record<string, unknown>): PatientProfile {
   return {
-    id:         r.id           as string,
-    authUid:    r.auth_uid     as string | null,
-    givenName:  r.given_name   as string,
-    familyName: r.family_name  as string,
-    email:      r.email        as string | null,
-    phone:      r.phone        as string | null,
-    dob:        r.dob          as string | null,
-    sex:        r.sex          as string | null,
-    createdAt:  r.created_at   as string,
+    id: r.id as string,
+    authUid: r.auth_uid as string | null,
+    givenName: r.given_name as string,
+    familyName: r.family_name as string,
+    email: r.email as string | null,
+    phone: r.phone as string | null,
+    dob: r.dob as string | null,
+    sex: r.sex as string | null,
+    createdAt: r.created_at as string,
   };
 }
 
 // ─── Patient profile ──────────────────────────────────────────────────────────
 
 /** Fetch a patient by their Supabase auth UID (stored as text in auth_uid). */
-export async function getPatientProfile(authUid: string): Promise<ServiceResult<PatientProfile>> {
+export async function getPatientProfile(
+  authUid: string,
+): Promise<ServiceResult<PatientProfile>> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
 
   const { data, error } = await supabase
     .from("patients")
-    .select("id, auth_uid, given_name, family_name, email, phone, dob, sex, created_at")
+    .select(
+      "id, auth_uid, given_name, family_name, email, phone, dob, sex, created_at",
+    )
     .eq("auth_uid", authUid)
     .maybeSingle();
 
@@ -97,28 +101,36 @@ export async function getPatientProfile(authUid: string): Promise<ServiceResult<
     logger.error("[patientService] getPatientProfile:", error.message);
     return { data: null, error: error.message };
   }
-  if (!data) return { data: null, error: "No patient profile found for this account." };
+  if (!data)
+    return { data: null, error: "No patient profile found for this account." };
 
   return { data: rowToProfile(data), error: null };
 }
 
 export async function updatePatientProfile(
   patientId: string,
-  updates: Partial<Pick<PatientProfile, "givenName" | "familyName" | "phone" | "dob">>,
+  updates: Partial<
+    Pick<PatientProfile, "givenName" | "familyName" | "phone" | "dob">
+  >,
 ): Promise<ServiceResult<PatientProfile>> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
 
-  const payload: Record<string, unknown> = { updated_at: new Date().toISOString() };
-  if (updates.givenName  !== undefined) payload.given_name  = updates.givenName;
-  if (updates.familyName !== undefined) payload.family_name = updates.familyName;
-  if (updates.phone      !== undefined) payload.phone       = updates.phone;
-  if (updates.dob        !== undefined) payload.dob         = updates.dob;
+  const payload: Record<string, unknown> = {
+    updated_at: new Date().toISOString(),
+  };
+  if (updates.givenName !== undefined) payload.given_name = updates.givenName;
+  if (updates.familyName !== undefined)
+    payload.family_name = updates.familyName;
+  if (updates.phone !== undefined) payload.phone = updates.phone;
+  if (updates.dob !== undefined) payload.dob = updates.dob;
 
   const { data, error } = await supabase
     .from("patients")
     .update(payload)
     .eq("id", patientId)
-    .select("id, auth_uid, given_name, family_name, email, phone, dob, sex, created_at")
+    .select(
+      "id, auth_uid, given_name, family_name, email, phone, dob, sex, created_at",
+    )
     .single();
 
   if (error) {
@@ -130,12 +142,16 @@ export async function updatePatientProfile(
 
 // ─── Vitals ───────────────────────────────────────────────────────────────────
 
-export async function getVitals(patientId: string): Promise<ServiceResult<Vital[]>> {
+export async function getVitals(
+  patientId: string,
+): Promise<ServiceResult<Vital[]>> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
 
   const { data, error } = await supabase
     .from("vitals")
-    .select("id, patient_id, visit_id, height_cm, weight_kg, temp_c, pulse_bpm, systolic, diastolic, spo2, bmi, taken_at")
+    .select(
+      "id, patient_id, visit_id, height_cm, weight_kg, temp_c, pulse_bpm, systolic, diastolic, spo2, bmi, taken_at",
+    )
     .eq("patient_id", patientId)
     .order("taken_at", { ascending: false });
 
@@ -146,18 +162,18 @@ export async function getVitals(patientId: string): Promise<ServiceResult<Vital[
 
   return {
     data: (data || []).map((v) => ({
-      id:        v.id,
+      id: v.id,
       patientId: v.patient_id,
-      visitId:   v.visit_id,
-      heightCm:  v.height_cm,
-      weightKg:  v.weight_kg,
-      tempC:     v.temp_c,
-      pulseBpm:  v.pulse_bpm,
-      systolic:  v.systolic,
+      visitId: v.visit_id,
+      heightCm: v.height_cm,
+      weightKg: v.weight_kg,
+      tempC: v.temp_c,
+      pulseBpm: v.pulse_bpm,
+      systolic: v.systolic,
       diastolic: v.diastolic,
-      spo2:      v.spo2,
-      bmi:       v.bmi,
-      takenAt:   v.taken_at,
+      spo2: v.spo2,
+      bmi: v.bmi,
+      takenAt: v.taken_at,
     })),
     error: null,
   };
@@ -184,15 +200,15 @@ export async function addVital(
     .insert({
       id,
       patient_id: patientId,
-      systolic:   vital.bloodPressureSystolic  ?? null,
-      diastolic:  vital.bloodPressureDiastolic ?? null,
-      weight_kg:  vital.weightKg  ?? null,
-      temp_c:     vital.tempC     ?? null,
-      pulse_bpm:  vital.pulseBpm  ?? null,
-      spo2:       vital.spo2      ?? null,
-      height_cm:  vital.heightCm  ?? null,
-      taken_at:   new Date().toISOString(),
-      flags:      [],
+      systolic: vital.bloodPressureSystolic ?? null,
+      diastolic: vital.bloodPressureDiastolic ?? null,
+      weight_kg: vital.weightKg ?? null,
+      temp_c: vital.tempC ?? null,
+      pulse_bpm: vital.pulseBpm ?? null,
+      spo2: vital.spo2 ?? null,
+      height_cm: vital.heightCm ?? null,
+      taken_at: new Date().toISOString(),
+      flags: [],
     })
     .select()
     .single();
@@ -204,18 +220,18 @@ export async function addVital(
 
   return {
     data: {
-      id:        data.id,
+      id: data.id,
       patientId: data.patient_id,
-      visitId:   data.visit_id,
-      heightCm:  data.height_cm,
-      weightKg:  data.weight_kg,
-      tempC:     data.temp_c,
-      pulseBpm:  data.pulse_bpm,
-      systolic:  data.systolic,
+      visitId: data.visit_id,
+      heightCm: data.height_cm,
+      weightKg: data.weight_kg,
+      tempC: data.temp_c,
+      pulseBpm: data.pulse_bpm,
+      systolic: data.systolic,
       diastolic: data.diastolic,
-      spo2:      data.spo2,
-      bmi:       data.bmi,
-      takenAt:   data.taken_at,
+      spo2: data.spo2,
+      bmi: data.bmi,
+      takenAt: data.taken_at,
     },
     error: null,
   };
@@ -223,12 +239,16 @@ export async function addVital(
 
 // ─── Medications (dispenses) ──────────────────────────────────────────────────
 
-export async function getMedications(patientId: string): Promise<ServiceResult<Medication[]>> {
+export async function getMedications(
+  patientId: string,
+): Promise<ServiceResult<Medication[]>> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
 
   const { data, error } = await supabase
     .from("dispenses")
-    .select("id, patient_id, visit_id, item_name, dosage, directions, dispensed_at")
+    .select(
+      "id, patient_id, visit_id, item_name, dosage, directions, dispensed_at",
+    )
     .eq("patient_id", patientId)
     .order("dispensed_at", { ascending: false });
 
@@ -239,12 +259,12 @@ export async function getMedications(patientId: string): Promise<ServiceResult<M
 
   return {
     data: (data || []).map((m) => ({
-      id:          m.id,
-      patientId:   m.patient_id,
-      visitId:     m.visit_id,
-      itemName:    m.item_name,
-      dosage:      m.dosage,
-      directions:  m.directions,
+      id: m.id,
+      patientId: m.patient_id,
+      visitId: m.visit_id,
+      itemName: m.item_name,
+      dosage: m.dosage,
+      directions: m.directions,
       dispensedAt: m.dispensed_at,
     })),
     error: null,
@@ -263,11 +283,11 @@ export async function addMedication(
     .from("dispenses")
     .insert({
       id,
-      patient_id:   patientId,
-      item_name:    med.name,
-      dosage:       med.dosage       ?? null,
-      directions:   med.instructions ?? null,
-      qty:          1,
+      patient_id: patientId,
+      item_name: med.name,
+      dosage: med.dosage ?? null,
+      directions: med.instructions ?? null,
+      qty: 1,
       dispensed_by: "staff",
       dispensed_at: new Date().toISOString(),
     })
@@ -281,12 +301,12 @@ export async function addMedication(
 
   return {
     data: {
-      id:          data.id,
-      patientId:   data.patient_id,
-      visitId:     data.visit_id,
-      itemName:    data.item_name,
-      dosage:      data.dosage,
-      directions:  data.directions,
+      id: data.id,
+      patientId: data.patient_id,
+      visitId: data.visit_id,
+      itemName: data.item_name,
+      dosage: data.dosage,
+      directions: data.directions,
       dispensedAt: data.dispensed_at,
     },
     error: null,
@@ -295,18 +315,25 @@ export async function addMedication(
 
 // ─── Visits ───────────────────────────────────────────────────────────────────
 
-export async function getVisits(patientId: string): Promise<ServiceResult<Visit[]>> {
+export async function getVisits(
+  patientId: string,
+): Promise<ServiceResult<Visit[]>> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
 
   const { data, error } = await supabase
     .from("visits")
-    .select(`
+    .select(
+      `
       id, patient_id, started_at, site_name, status,
       consultations ( soap_assessment, soap_subjective, created_at )
-    `)
+    `,
+    )
     .eq("patient_id", patientId)
     .order("started_at", { ascending: false })
-    .order("created_at", { referencedTable: "consultations", ascending: false });
+    .order("created_at", {
+      referencedTable: "consultations",
+      ascending: false,
+    });
 
   if (error) {
     logger.error("[patientService] getVisits:", error.message);
@@ -315,15 +342,17 @@ export async function getVisits(patientId: string): Promise<ServiceResult<Visit[
 
   return {
     data: (data || []).map((v) => {
-      const consult = Array.isArray(v.consultations) ? v.consultations[0] : v.consultations;
+      const consult = Array.isArray(v.consultations)
+        ? v.consultations[0]
+        : v.consultations;
       return {
-        id:         v.id,
-        patientId:  v.patient_id,
-        startedAt:  v.started_at,
-        siteName:   v.site_name,
-        status:     v.status,
-        diagnosis:  consult?.soap_assessment ?? null,
-        notes:      consult?.soap_subjective ?? null,
+        id: v.id,
+        patientId: v.patient_id,
+        startedAt: v.started_at,
+        siteName: v.site_name,
+        status: v.status,
+        diagnosis: consult?.soap_assessment ?? null,
+        notes: consult?.soap_subjective ?? null,
       };
     }),
     error: null,
@@ -332,19 +361,24 @@ export async function getVisits(patientId: string): Promise<ServiceResult<Visit[
 
 export async function addVisit(
   patientId: string,
-  visit: { notes?: string | null; diagnosis?: string | null; siteName?: string },
+  visit: {
+    notes?: string | null;
+    diagnosis?: string | null;
+    siteName?: string;
+  },
 ): Promise<ServiceResult<Visit>> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
 
   const visitId = crypto.randomUUID();
+  const startedAt = new Date().toISOString();
 
   // Create the visit row
   const { error: visitError } = await supabase.from("visits").insert({
-    id:         visitId,
+    id: visitId,
     patient_id: patientId,
-    started_at: new Date().toISOString(),
-    site_name:  visit.siteName ?? "Portal entry",
-    status:     "closed",
+    started_at: startedAt,
+    site_name: visit.siteName ?? "Portal entry",
+    status: "closed",
   });
   if (visitError) {
     logger.error("[patientService] addVisit (visit):", visitError.message);
@@ -353,32 +387,56 @@ export async function addVisit(
 
   // If there are notes/diagnosis, create a consultation record too
   if (visit.notes || visit.diagnosis) {
-    const { error: consultError } = await supabase.from("consultations").insert({
-      id:               crypto.randomUUID(),
-      patient_id:       patientId,
-      visit_id:         visitId,
-      provider_name:    "Staff (portal)",
-      soap_subjective:  visit.notes      ?? "",
-      soap_objective:   "",
-      soap_assessment:  visit.diagnosis  ?? "",
-      soap_plan:        "",
-      provisional_dx:   [],
-    });
+    const { error: consultError } = await supabase
+      .from("consultations")
+      .insert({
+        id: crypto.randomUUID(),
+        patient_id: patientId,
+        visit_id: visitId,
+        provider_name: "Staff (portal)",
+        soap_subjective: visit.notes ?? "",
+        soap_objective: "",
+        soap_assessment: visit.diagnosis ?? "",
+        soap_plan: "",
+        provisional_dx: [],
+      });
     if (consultError) {
-      logger.error("[patientService] addVisit (consultation):", consultError.message);
-      return { data: null, error: `Visit was saved but clinical notes failed: ${consultError.message}` };
+      logger.error(
+        "[patientService] addVisit (consultation):",
+        consultError.message,
+      );
+
+      const { error: rollbackError } = await supabase
+        .from("visits")
+        .delete()
+        .eq("id", visitId);
+      if (rollbackError) {
+        logger.error(
+          "[patientService] addVisit (rollback):",
+          rollbackError.message,
+        );
+        return {
+          data: null,
+          error: `Consultation save failed and visit cleanup failed: ${consultError.message}. Cleanup error: ${rollbackError.message}`,
+        };
+      }
+
+      return {
+        data: null,
+        error: `Consultation save failed; visit was rolled back: ${consultError.message}`,
+      };
     }
   }
 
   return {
     data: {
-      id:        visitId,
+      id: visitId,
       patientId,
-      startedAt: new Date().toISOString(),
-      siteName:  visit.siteName ?? "Portal entry",
-      status:    "closed",
+      startedAt,
+      siteName: visit.siteName ?? "Portal entry",
+      status: "closed",
       diagnosis: visit.diagnosis ?? null,
-      notes:     visit.notes    ?? null,
+      notes: visit.notes ?? null,
     },
     error: null,
   };
@@ -386,12 +444,16 @@ export async function addVisit(
 
 // ─── Staff helpers ────────────────────────────────────────────────────────────
 
-export async function getAllPatients(): Promise<ServiceResult<PatientProfile[]>> {
+export async function getAllPatients(): Promise<
+  ServiceResult<PatientProfile[]>
+> {
   if (!supabase) return { data: null, error: "Supabase not configured" };
 
   const { data, error } = await supabase
     .from("patients")
-    .select("id, auth_uid, given_name, family_name, email, phone, dob, sex, created_at")
+    .select(
+      "id, auth_uid, given_name, family_name, email, phone, dob, sex, created_at",
+    )
     .order("created_at", { ascending: false });
 
   if (error) {


### PR DESCRIPTION
### Motivation
- Prevent returning a successful visit when the follow-up `consultations` insert fails, which could leave a visit row without its clinical note and cause inconsistent UI/state.

### Description
- Updated `addVisit` in `src/services/patientService.ts` to generate and reuse a single `startedAt` timestamp for the visit write and the returned payload.
- If the `consultations` insert fails, the code now attempts a compensating rollback by deleting the newly-created `visits` row.
- If the rollback delete also fails, both errors are logged and a combined error message is returned to surface the full failure path.
- The function always returns a failure result on consultation-related errors instead of returning a partially-saved visit.

### Testing
- Ran `npm run typecheck` which passed.
- Pre-commit checks including `eslint`, `prettier`, and `tsc-files --noEmit` ran during the commit and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e57136faf883328867214d5f1c6ba7)