### PR TITLE
Fix Vite env fallback and make dispenses policy migration idempotent

### DIFF
--- a/supabase/migrations/20250930065243_empty_band.sql
+++ b/supabase/migrations/20250930065243_empty_band.sql
@@ -170,13 +170,15 @@ create table if not exists dispenses (
 alter table dispenses enable row level security;
 do $$
 begin
-  if not exists (
+  if exists (
     select 1
     from pg_policies
     where schemaname = 'public'
       and tablename = 'dispenses'
       and policyname = 'Allow authenticated access to dispenses'
   ) then
+    raise notice 'Skipping policy "Allow authenticated access to dispenses" because it already exists';
+  else
     create policy "Allow authenticated access to dispenses"
       on dispenses
       for all

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,16 +6,21 @@ import { resolve } from "path";
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const define: Record<string, string> = {};
+  const readEnv = (key: string) => env[key]?.trim();
 
-  if (!env.VITE_SUPABASE_URL && env.SUPABASE_URL) {
-    define["import.meta.env.VITE_SUPABASE_URL"] = JSON.stringify(
-      env.SUPABASE_URL,
-    );
+  const hasClientSupabaseUrl = Boolean(readEnv("VITE_SUPABASE_URL"));
+  const hasClientSupabaseAnonKey = Boolean(readEnv("VITE_SUPABASE_ANON_KEY"));
+  const serverSupabaseUrl = readEnv("SUPABASE_URL");
+  const serverSupabaseAnonKey = readEnv("SUPABASE_ANON_KEY");
+
+  if (!hasClientSupabaseUrl && serverSupabaseUrl) {
+    define["import.meta.env.VITE_SUPABASE_URL"] =
+      JSON.stringify(serverSupabaseUrl);
   }
 
-  if (!env.VITE_SUPABASE_ANON_KEY && env.SUPABASE_ANON_KEY) {
+  if (!hasClientSupabaseAnonKey && serverSupabaseAnonKey) {
     define["import.meta.env.VITE_SUPABASE_ANON_KEY"] = JSON.stringify(
-      env.SUPABASE_ANON_KEY,
+      serverSupabaseAnonKey,
     );
   }
 


### PR DESCRIPTION
### Motivation

- Prevent accidental replacement of `import.meta.env.VITE_SUPABASE_*` with empty values at build time which can force the app into a “Supabase not configured” state when valid `.env` values exist.
- Avoid migration failures caused by re-creating an already-existing RLS policy on `dispenses` that aborts the migration chain.

### Description

- Updated `vite.config.ts` to read env values via `loadEnv()` with a trimmed `readEnv` helper and only define `import.meta.env.VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` when client vars are missing and server `SUPABASE_*` vars are non-empty.
- Made the `dispenses` policy creation in `supabase/migrations/20250930065243_empty_band.sql` explicitly idempotent by checking `pg_policies` first and emitting a notice and skipping creation if the policy already exists.
- Changes are limited to `vite.config.ts` and `supabase/migrations/20250930065243_empty_band.sql` to address the two reported issues.

### Testing

- Ran `npm run typecheck` and it completed successfully.
- Ran `npm run build` (which runs `tsc -b && vite build`) and it completed successfully producing a production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e571f48e108332a9ffbc3b4ee8ba23)