### PR TITLE
[PR #9 follow-up] Fix addVisit consultation failure handling

### DIFF
--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -406,19 +406,17 @@ export async function addVisit(
         consultError.message,
       );
       // Best-effort rollback so we do not leave a visit without its clinical note.
-
       const { error: rollbackError } = await supabase
         .from("visits")
         .delete()
         .eq("id", visitId);
+
       if (rollbackError) {
         logger.error(
           "[patientService] addVisit (rollback visit):",
           rollbackError.message,
         );
-          "[patientService] addVisit (rollback):",
-          rollbackError.message,
-        );
+
         return {
           data: null,
           error: `Consultation save failed and visit cleanup failed: ${consultError.message}. Cleanup error: ${rollbackError.message}`,
@@ -427,9 +425,6 @@ export async function addVisit(
 
       return {
         data: null,
-        error: rollbackError
-          ? `Failed to save clinical notes (${consultError.message}) and failed to roll back visit (${rollbackError.message}).`
-          : `Failed to save clinical notes: ${consultError.message}`,
         error: `Consultation save failed; visit was rolled back: ${consultError.message}`,
       };
     }


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where `addVisit` could report success after a failed `consultations` insert, leaving a `visits` row without its clinical note and causing inconsistent state.

### Description
- Update `src/services/patientService.ts` so the `addVisit` consultation-error branch always returns a deterministic error, preserves the existing best-effort rollback of the created `visits` row, and surfaces both consultation and rollback errors when rollback fails.

### Testing
- Ran `npm run typecheck` which completed successfully.
- Ran `npm run lint` which failed due to many pre-existing repository lint errors unrelated to this targeted change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5729529c88332974b141f2c8afb33)