### PR TITLE
Fix Vite Supabase env fallback and make dispenses policy idempotent in migration

### DIFF
--- a/supabase/migrations/20250930065243_empty_band.sql
+++ b/supabase/migrations/20250930065243_empty_band.sql
@@ -172,10 +172,12 @@ do $$
 begin
   if not exists (
     select 1
-    from pg_policies
-    where schemaname = 'public'
-      and tablename = 'dispenses'
-      and policyname = 'Allow authenticated access to dispenses'
+    from pg_policy p
+    join pg_class c on c.oid = p.polrelid
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relname = 'dispenses'
+      and p.polname = 'Allow authenticated access to dispenses'
   ) then
     create policy "Allow authenticated access to dispenses"
       on dispenses

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,14 +6,19 @@ import { resolve } from "path";
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const define: Record<string, string> = {};
+  const hasValue = (value?: string) =>
+    Boolean(value && value.trim().length > 0);
 
-  if (!env.VITE_SUPABASE_URL && env.SUPABASE_URL) {
+  if (!hasValue(env.VITE_SUPABASE_URL) && hasValue(env.SUPABASE_URL)) {
     define["import.meta.env.VITE_SUPABASE_URL"] = JSON.stringify(
       env.SUPABASE_URL,
     );
   }
 
-  if (!env.VITE_SUPABASE_ANON_KEY && env.SUPABASE_ANON_KEY) {
+  if (
+    !hasValue(env.VITE_SUPABASE_ANON_KEY) &&
+    hasValue(env.SUPABASE_ANON_KEY)
+  ) {
     define["import.meta.env.VITE_SUPABASE_ANON_KEY"] = JSON.stringify(
       env.SUPABASE_ANON_KEY,
     );


### PR DESCRIPTION
### Motivation

- Prevent build-time replacement of valid `import.meta.env.VITE_SUPABASE_*` values with empty strings when `SUPABASE_*` are present but `VITE_*` were loaded from `.env` into Vite; and avoid migration failures caused by re-creating an already-existing `dispenses` policy.

### Description

- Add a `hasValue()` guard in `vite.config.ts` and only map `SUPABASE_URL`/`SUPABASE_ANON_KEY` into `import.meta.env.VITE_SUPABASE_*` when the `VITE_` variant is truly unset or blank, preserving `.env`-loaded Vite vars (`vite.config.ts`).
- Make the `dispenses` policy creation in `supabase/migrations/20250930065243_empty_band.sql` idempotent by checking the Postgres catalog using `pg_policy` joined with `pg_class` and `pg_namespace` so the migration skips creating the policy if it already exists.

### Testing

- Ran `npm run typecheck` and it completed successfully (no TypeScript errors).
- Ran `npm run build` (which runs `tsc -b && vite build`) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e572e26c9c8332961518fae4e48663)