### PR TITLE
Fix Vite Supabase env injection and make dispenses policy migration idempotent

### DIFF
--- a/supabase/migrations/20250930065243_empty_band.sql
+++ b/supabase/migrations/20250930065243_empty_band.sql
@@ -168,9 +168,10 @@ create table if not exists dispenses (
 );
 
 alter table dispenses enable row level security;
+-- Policy is already created in 20250930060647_old_dream.sql; guard re-creation.
 do $$
 begin
-  if exists (
+  if not exists (
     select 1
     from pg_policy p
     join pg_class c on c.oid = p.polrelid
@@ -179,8 +180,6 @@ begin
       and c.relname = 'dispenses'
       and p.polname = 'Allow authenticated access to dispenses'
   ) then
-    raise notice 'Skipping policy "Allow authenticated access to dispenses" because it already exists';
-  else
     create policy "Allow authenticated access to dispenses"
       on dispenses
       for all

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,19 +6,6 @@ import { resolve } from "path";
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const define: Record<string, string> = {};
-  const hasValue = (value?: string) =>
-    Boolean(value && value.trim().length > 0);
-
-  if (!hasValue(env.VITE_SUPABASE_URL) && hasValue(env.SUPABASE_URL)) {
-    define["import.meta.env.VITE_SUPABASE_URL"] = JSON.stringify(
-      env.SUPABASE_URL,
-    );
-  }
-
-  if (
-    !hasValue(env.VITE_SUPABASE_ANON_KEY) &&
-    hasValue(env.SUPABASE_ANON_KEY)
-  ) {
   const readEnv = (key: string) => env[key]?.trim();
 
   const hasClientSupabaseUrl = Boolean(readEnv("VITE_SUPABASE_URL"));


### PR DESCRIPTION
### Motivation

- Prevent Vite from hard-replacing `import.meta.env.VITE_SUPABASE_*` with empty values when `.env` values are present but not loaded into `process.env` at config time. 
- Avoid migration failures caused by re-creating an already-existing RLS policy for `dispenses` during ordered migration runs.

### Description

- Adjusted `vite.config.ts` to remove the broken empty-define path and use `loadEnv(...)` + a `readEnv` check so `import.meta.env.VITE_SUPABASE_URL` / `import.meta.env.VITE_SUPABASE_ANON_KEY` are injected only when the corresponding `VITE_*` values are actually missing. 
- Hardened `supabase/migrations/20250930065243_empty_band.sql` by guarding creation of policy `"Allow authenticated access to dispenses"` with an `if not exists (...)` check and added a clarifying inline note about the earlier migration that creates the same policy.

### Testing

- Ran `npm run typecheck` and the TypeScript check completed successfully. 
- Ran `npm run build` (which runs `tsc -b` and `vite build`) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e576223b048332bda8b730317d27fb)