### PR TITLE
fix: enforce rollback verification in addVisit consultation failure path

### DIFF
--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -405,31 +405,33 @@ export async function addVisit(
         "[patientService] addVisit (consultation):",
         consultError.message,
       );
-      // Best-effort rollback so we do not leave a visit without its clinical note.
-
-      const { error: rollbackError } = await supabase
+      // Roll back the inserted visit so we do not leave partial writes.
+      const { data: rollbackRows, error: rollbackError } = await supabase
         .from("visits")
         .delete()
-        .eq("id", visitId);
-      if (rollbackError) {
+        .eq("id", visitId)
+        .select("id");
+
+      const rollbackRemovedVisit = (rollbackRows ?? []).some(
+        (row) => row.id === visitId,
+      );
+
+      if (rollbackError || !rollbackRemovedVisit) {
+        const cleanupMessage = rollbackError
+          ? rollbackError.message
+          : "No visit rows were deleted during rollback.";
         logger.error(
           "[patientService] addVisit (rollback visit):",
-          rollbackError.message,
-        );
-          "[patientService] addVisit (rollback):",
-          rollbackError.message,
+          cleanupMessage,
         );
         return {
           data: null,
-          error: `Consultation save failed and visit cleanup failed: ${consultError.message}. Cleanup error: ${rollbackError.message}`,
+          error: `Consultation save failed and visit cleanup failed: ${consultError.message}. Cleanup error: ${cleanupMessage}`,
         };
       }
 
       return {
         data: null,
-        error: rollbackError
-          ? `Failed to save clinical notes (${consultError.message}) and failed to roll back visit (${rollbackError.message}).`
-          : `Failed to save clinical notes: ${consultError.message}`,
         error: `Consultation save failed; visit was rolled back: ${consultError.message}`,
       };
     }


### PR DESCRIPTION
### Motivation
- Prevent inconsistent partial writes when `addVisit` creates a `visits` row but the subsequent `consultations` insert fails; the previous rollback treated a transport-success (no error) as success which can be a no-op under current RLS policies.

### Description
- In `src/services/patientService.ts` the consultation-failure branch now deletes the inserted visit with an accompanying `.select("id")`, inspects the returned rows to confirm the `visitId` was actually removed, treats either a transport error or zero-row deletion as a rollback failure, logs a single clear `cleanupMessage`, and consolidates duplicate/contradictory rollback error handling into a single explicit error return.

### Testing
- Ran `npm run typecheck` which completed successfully, and `npm run lint` which failed due to many pre-existing repository-wide lint violations unrelated to this targeted change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e576ff1f008332a70fe23f7f62e7bf)