### PR TITLE
Fix Vite env mapping and make dispenses policy migration idempotent

### DIFF
--- a/supabase/migrations/20250930065243_empty_band.sql
+++ b/supabase/migrations/20250930065243_empty_band.sql
@@ -170,17 +170,12 @@ create table if not exists dispenses (
 alter table dispenses enable row level security;
 do $$
 begin
-  if exists (
+  if not exists (
     select 1
     from pg_policy p
-    join pg_class c on c.oid = p.polrelid
-    join pg_namespace n on n.oid = c.relnamespace
-    where n.nspname = 'public'
-      and c.relname = 'dispenses'
-      and p.polname = 'Allow authenticated access to dispenses'
+    where p.polname = 'Allow authenticated access to dispenses'
+      and p.polrelid = 'public.dispenses'::regclass
   ) then
-    raise notice 'Skipping policy "Allow authenticated access to dispenses" because it already exists';
-  else
     create policy "Allow authenticated access to dispenses"
       on dispenses
       for all

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,19 +6,6 @@ import { resolve } from "path";
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const define: Record<string, string> = {};
-  const hasValue = (value?: string) =>
-    Boolean(value && value.trim().length > 0);
-
-  if (!hasValue(env.VITE_SUPABASE_URL) && hasValue(env.SUPABASE_URL)) {
-    define["import.meta.env.VITE_SUPABASE_URL"] = JSON.stringify(
-      env.SUPABASE_URL,
-    );
-  }
-
-  if (
-    !hasValue(env.VITE_SUPABASE_ANON_KEY) &&
-    hasValue(env.SUPABASE_ANON_KEY)
-  ) {
   const readEnv = (key: string) => env[key]?.trim();
 
   const hasClientSupabaseUrl = Boolean(readEnv("VITE_SUPABASE_URL"));


### PR DESCRIPTION
### Motivation

- Prevent build-time replacement of `import.meta.env.VITE_SUPABASE_*` with empty strings when `.env` values are loaded via `loadEnv()` so client-side Supabase keys are preserved.
- Avoid migration failures caused by attempting to create an already-existing `dispenses` policy during ordered migration runs.

### Description

- Updated `vite.config.ts` to use `loadEnv()`-derived values via a single `readEnv()` helper and removed the earlier `define` override logic that could force empty `import.meta.env` replacements, keeping server→client fallbacks only when `VITE_*` vars are absent and `SUPABASE_*` vars exist.
- Modified `supabase/migrations/20250930065243_empty_band.sql` to create the `"Allow authenticated access to dispenses"` policy only when it does not already exist by checking `p.polname` and `p.polrelid = 'public.dispenses'::regclass`, making the migration idempotent.

### Testing

- Ran `npm run typecheck` and it completed successfully.
- Ran `npm run build` (which runs `tsc -b && vite build`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e577524bb48332a6ceaea904d46672)