### PR TITLE
test: add regression coverage for addVisit consultation failure handling

### DIFF
--- a/src/services/patientService.addVisit.test.ts
+++ b/src/services/patientService.addVisit.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fromMock, loggerErrorMock } = vi.hoisted(() => ({
+  fromMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+}));
+
+vi.mock("@/lib/supabaseClient", () => ({
+  supabase: {
+    from: fromMock,
+  },
+}));
+
+vi.mock("@/lib/logger", () => ({
+  error: loggerErrorMock,
+}));
+
+import { addVisit } from "./patientService";
+
+describe("patientService.addVisit", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns an error and rolls back the visit when consultation insert fails", async () => {
+    const visitsInsertMock = vi.fn().mockResolvedValue({ error: null });
+    const consultInsertMock = vi.fn().mockResolvedValue({
+      error: { message: "consultation insert denied" },
+    });
+    const rollbackEqMock = vi.fn().mockResolvedValue({ error: null });
+    const visitsDeleteMock = vi.fn(() => ({ eq: rollbackEqMock }));
+
+    fromMock.mockImplementation((table: string) => {
+      if (table === "visits") {
+        return {
+          insert: visitsInsertMock,
+          delete: visitsDeleteMock,
+        };
+      }
+
+      if (table === "consultations") {
+        return {
+          insert: consultInsertMock,
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    vi.spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce("11111111-1111-1111-1111-111111111111")
+      .mockReturnValueOnce("22222222-2222-2222-2222-222222222222");
+
+    const result = await addVisit("patient-1", {
+      notes: "headache",
+      diagnosis: "viral illness",
+    });
+
+    expect(result.data).toBeNull();
+    expect(result.error).toContain(
+      "Consultation save failed; visit was rolled back",
+    );
+    expect(visitsInsertMock).toHaveBeenCalledOnce();
+    expect(consultInsertMock).toHaveBeenCalledOnce();
+    expect(visitsDeleteMock).toHaveBeenCalledOnce();
+    expect(rollbackEqMock).toHaveBeenCalledWith(
+      "id",
+      "11111111-1111-1111-1111-111111111111",
+    );
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      "[patientService] addVisit (consultation):",
+      "consultation insert denied",
+    );
+  });
+
+  it("returns a combined error when consultation insert fails and rollback also fails", async () => {
+    const visitsInsertMock = vi.fn().mockResolvedValue({ error: null });
+    const consultInsertMock = vi.fn().mockResolvedValue({
+      error: { message: "consultation insert denied" },
+    });
+    const rollbackEqMock = vi.fn().mockResolvedValue({
+      error: { message: "rollback denied" },
+    });
+    const visitsDeleteMock = vi.fn(() => ({ eq: rollbackEqMock }));
+
+    fromMock.mockImplementation((table: string) => {
+      if (table === "visits") {
+        return {
+          insert: visitsInsertMock,
+          delete: visitsDeleteMock,
+        };
+      }
+
+      if (table === "consultations") {
+        return {
+          insert: consultInsertMock,
+        };
+      }
+
+      throw new Error(`Unexpected table: ${table}`);
+    });
+
+    vi.spyOn(crypto, "randomUUID")
+      .mockReturnValueOnce("11111111-1111-1111-1111-111111111111")
+      .mockReturnValueOnce("22222222-2222-2222-2222-222222222222");
+
+    const result = await addVisit("patient-1", {
+      notes: "headache",
+      diagnosis: "viral illness",
+    });
+
+    expect(result.data).toBeNull();
+    expect(result.error).toContain(
+      "Consultation save failed and visit cleanup failed",
+    );
+    expect(result.error).toContain("rollback denied");
+    expect(visitsDeleteMock).toHaveBeenCalledOnce();
+    expect(rollbackEqMock).toHaveBeenCalledWith(
+      "id",
+      "11111111-1111-1111-1111-111111111111",
+    );
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      "[patientService] addVisit (rollback visit):",
+      "rollback denied",
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent regression of a P1 bug where a failed `consultations` insert could leave a `visits` row and cause the UI to report success despite the clinical note not being saved.
- Ensure `addVisit` returns failure and performs best-effort rollback when consultation creation fails so persisted data remains consistent.

### Description
- Adds a focused regression test file at `src/services/patientService.addVisit.test.ts` that exercises the consultation-failure and rollback paths for `addVisit`.
- Tests mock Supabase and logger calls using `vi.hoisted` to avoid hoisting/mocking order issues and assert expected logging and delete calls.
- Adjusts test UUID mocks to full UUID strings to satisfy TypeScript checks and ensure pre-commit `tsc-files --noEmit` passes.
- Verifies the existing `addVisit` logic in `src/services/patientService.ts` correctly detects consultation insert errors and attempts a visit rollback before returning an error.

### Testing
- Ran `npm test -- src/services/patientService.addVisit.test.ts` and the suite passed with `2/2` tests succeeding.
- Pre-commit TypeScript check `tsc-files --noEmit` was executed as part of commit hooks and passed after updating mocked UUIDs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e579ffae008332aaec0c928b88d9a5)