### PR TITLE
fix: harden addVisit consultation persistence handling

### DIFF
--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -371,6 +371,9 @@ export async function addVisit(
 
   const visitId = crypto.randomUUID();
   const startedAt = new Date().toISOString();
+  const hasConsultationContent = Boolean(
+    visit.notes?.trim() || visit.diagnosis?.trim(),
+  );
 
   // Create the visit row
   const { error: visitError } = await supabase.from("visits").insert({
@@ -386,7 +389,7 @@ export async function addVisit(
   }
 
   // If there are notes/diagnosis, create a consultation record too
-  if (visit.notes || visit.diagnosis) {
+  if (hasConsultationContent) {
     const { error: consultError } = await supabase
       .from("consultations")
       .insert({
@@ -409,7 +412,8 @@ export async function addVisit(
       const { error: rollbackError } = await supabase
         .from("visits")
         .delete()
-        .eq("id", visitId);
+        .eq("id", visitId)
+        .eq("patient_id", patientId);
 
       if (rollbackError) {
         logger.error(


### PR DESCRIPTION
### Motivation
- Prevent returning success when a visit is saved but the associated clinical consultation fails to persist, which can leave inconsistent data. 
- Tighten cleanup semantics so rollback deletes are scoped safely to the created visit for the correct patient.

### Description
- Added a `hasConsultationContent` check in `src/services/patientService.ts` to only insert a `consultations` row when `notes` or `diagnosis` contain non-whitespace content. 
- Preserved the existing consultation-insert error handling and improved the rollback delete to include both `id` and `patient_id` (`.eq("id", visitId).eq("patient_id", patientId)`) so cleanup targets the correct row. 
- No other behavioral changes; function still returns an error when consultation insert fails and attempts best-effort rollback.

### Testing
- Ran type checking with `npm run typecheck`, which completed successfully. 
- Pre-commit tasks executed during the commit (including `eslint --fix`, `prettier --write`, and `tsc-files --noEmit`) and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e57a86044c83329c025af97c7ce6c6)