### PR TITLE
Follow-up: harden addVisit consultation persistence handling

### DIFF
--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -387,7 +387,7 @@ export async function addVisit(
 
   // If there are notes/diagnosis, create a consultation record too
   if (visit.notes || visit.diagnosis) {
-    const { error: consultError } = await supabase
+    const { data: consultationRow, error: consultError } = await supabase
       .from("consultations")
       .insert({
         id: crypto.randomUUID(),
@@ -399,11 +399,15 @@ export async function addVisit(
         soap_assessment: visit.diagnosis ?? "",
         soap_plan: "",
         provisional_dx: [],
-      });
-    if (consultError) {
+      })
+      .select("id")
+      .single();
+    if (consultError || !consultationRow) {
+      const consultationFailureReason =
+        consultError?.message ?? "No consultation row returned";
       logger.error(
         "[patientService] addVisit (consultation):",
-        consultError.message,
+        consultationFailureReason,
       );
       // Best-effort rollback so we do not leave a visit without its clinical note.
       const { error: rollbackError } = await supabase
@@ -419,13 +423,13 @@ export async function addVisit(
 
         return {
           data: null,
-          error: `Consultation save failed and visit cleanup failed: ${consultError.message}. Cleanup error: ${rollbackError.message}`,
+          error: `Consultation save failed and visit cleanup failed: ${consultationFailureReason}. Cleanup error: ${rollbackError.message}`,
         };
       }
 
       return {
         data: null,
-        error: `Consultation save failed; visit was rolled back: ${consultError.message}`,
+        error: `Consultation save failed; visit was rolled back: ${consultationFailureReason}`,
       };
     }
   }


### PR DESCRIPTION
### Motivation
- A Codex review found that `addVisit` could report success after creating a `visits` row even if the subsequent `consultations` insert did not actually persist, causing inconsistent visit vs clinical note state. 
- The change aims to ensure the function only returns success when both the visit and its clinical note are confirmed persisted.

### Description
- Change the consultation insert in `src/services/patientService.ts` to capture the inserted row with `.select("id").single()` and inspect both `data` and `error` rather than relying only on awaiting the insert call. 
- Treat a missing returned row (`!consultationRow`) as a failure and normalize the failure reason into `consultationFailureReason` for logging and returned errors. 
- Preserve the existing best-effort rollback that deletes the created visit on consultation failure and improve error messages to include the normalized failure reason and any rollback error.

### Testing
- Ran `npm run typecheck` which succeeded. 
- Ran `npm run lint` which failed due to many pre-existing unrelated lint issues in the repo (not introduced by this change). 
- Verified the updated behavior by inspecting the modified `addVisit` flow to ensure failures during consultation writes result in a returned error and attempted visit rollback.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e57a4604b88332ab7868279a1c079a)