### PR TITLE
Harden Vite env fallback and make dispenses policy creation idempotent

### DIFF
--- a/supabase/migrations/20250930065243_empty_band.sql
+++ b/supabase/migrations/20250930065243_empty_band.sql
@@ -173,9 +173,10 @@ do $$
 begin
   if not exists (
     select 1
-    from pg_policy p
-    where p.polname = 'Allow authenticated access to dispenses'
-      and p.polrelid = 'public.dispenses'::regclass
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'dispenses'
+      and policyname = 'Allow authenticated access to dispenses'
   ) then
     create policy "Allow authenticated access to dispenses"
       on dispenses

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), "");
   const define: Record<string, string> = {};
   const readEnv = (key: string) => env[key]?.trim();
+  const isProduction = mode === "production";
 
   const hasClientSupabaseUrl = Boolean(readEnv("VITE_SUPABASE_URL"));
   const hasClientSupabaseAnonKey = Boolean(readEnv("VITE_SUPABASE_ANON_KEY"));
@@ -109,18 +110,14 @@ export default defineConfig(({ mode }) => {
       minify: "terser",
       terserOptions: {
         compress: {
-          drop_console: process.env.NODE_ENV === "production",
+          drop_console: isProduction,
           drop_debugger: true,
-          pure_funcs:
-            process.env.NODE_ENV === "production"
-              ? ["console.log", "console.info"]
-              : [],
+          pure_funcs: isProduction ? ["console.log", "console.info"] : [],
         },
       },
     },
     esbuild: {
-      drop:
-        process.env.NODE_ENV === "production" ? ["console", "debugger"] : [],
+      drop: isProduction ? ["console", "debugger"] : [],
     },
     plugins: [
       react(),


### PR DESCRIPTION
### Motivation

- Prevent build-time environment handling from depending on Node `process.env.NODE_ENV` and avoid accidental client env overrides or inconsistent minification/drop settings during Vite builds.
- Avoid migration failures caused by attempting to recreate the same RLS policy when migrations are applied in order.

### Description

- Added `isProduction = mode === "production"` to `vite.config.ts` and replaced `process.env.NODE_ENV` checks with `isProduction` for terser `pure_funcs`, `drop_console`, and `esbuild.drop` so build behavior follows Vite `mode` reliably while preserving the guarded client `define` mapping for `import.meta.env.VITE_SUPABASE_*`.
- Hardened the dispenses policy guard in `supabase/migrations/20250930065243_empty_band.sql` by querying `pg_policies` with `schemaname`, `tablename`, and `policyname` before creating the `Allow authenticated access to dispenses` policy to make the migration idempotent.

### Testing

- Ran `npm run typecheck` and it completed successfully with no type errors.
- Ran `npm run build` (which runs `tsc -b && vite build`) and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e58067c74c8332a1f78f19e22bbec8)