### PR TITLE
[Follow-up] Fix migration UUID type mismatches flagged in PR #40

### DIFF
--- a/supabase/migrations/20251028000000_add_patient_portal.sql
+++ b/supabase/migrations/20251028000000_add_patient_portal.sql
@@ -417,7 +417,7 @@ CREATE POLICY "Patients can send messages"
       SELECT patient_id FROM patient_portal_users WHERE id = auth.uid()
     )
     AND sender_type = 'patient'
-    AND sender_id = auth.uid()::text
+    AND sender_id = auth.uid()
   );
 
 CREATE POLICY "Patients can update own messages"
@@ -451,7 +451,7 @@ CREATE POLICY "Staff can send messages to patients"
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
     AND sender_type = 'staff'
-    AND sender_id = auth.uid()::text
+    AND sender_id = auth.uid()
   );
 
 -- ============================================================================

--- a/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
+++ b/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS conflict_resolutions (
 -- Conflict Audit Logs Table (append-only for compliance)
 CREATE TABLE IF NOT EXISTS conflict_audit_logs (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  conflict_id text NOT NULL REFERENCES conflict_resolutions(id) ON DELETE CASCADE,
+  conflict_id uuid NOT NULL REFERENCES conflict_resolutions(id) ON DELETE CASCADE,
   action text NOT NULL CHECK (action IN ('created', 'viewed', 'resolved', 'approved', 'rejected', 'appealed', 'auto_resolved')),
   actor_id uuid REFERENCES auth.users(id),
   actor_role text,

--- a/supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql
+++ b/supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql
@@ -35,7 +35,7 @@
 -- Create conflict_change_deltas table for granular field tracking
 CREATE TABLE IF NOT EXISTS conflict_change_deltas (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  conflict_id text NOT NULL REFERENCES conflict_resolutions(id) ON DELETE CASCADE,
+  conflict_id uuid NOT NULL REFERENCES conflict_resolutions(id) ON DELETE CASCADE,
   field_name text NOT NULL,
   old_value jsonb,
   new_value jsonb,


### PR DESCRIPTION
### Motivation
- Several migrations contained UUID/text type mismatches that will cause PostgreSQL to reject policy predicates and foreign key constraints, breaking `supabase db push` on fresh environments. 
- These fixes restore consistent UUID usage so RLS checks and FK references evaluate correctly during migration application.

### Description
- Updated `supabase/migrations/20251028000000_add_patient_portal.sql` to use `sender_id = auth.uid()` instead of `sender_id = auth.uid()::text` in patient message INSERT policies for both patient and staff senders. 
- Changed `conflict_audit_logs.conflict_id` to `uuid NOT NULL` in `supabase/migrations/20260125094038_add_conflict_resolution_system.sql` so it matches `conflict_resolutions(id)`. 
- Changed `conflict_change_deltas.conflict_id` to `uuid NOT NULL` in `supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql` so it matches `conflict_resolutions(id)`.

### Testing
- Ran a targeted search with `rg` for the problematic patterns and confirmed the strings `sender_id = auth.uid()::text` and `conflict_id text NOT NULL REFERENCES conflict_resolutions(id)` are no longer present. 
- Ran `git diff --check` to ensure there are no patch/whitespace issues and it returned clean. 
- Attempted `supabase --version` for CLI validation but the Supabase CLI is not installed in this environment so full runtime validation was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5c8e085208332b167aa77a6b690f1)