### PR TITLE
Fix Vite env define fallback safety and make dispenses policy creation idempotent

### DIFF
--- a/supabase/migrations/20250930065243_empty_band.sql
+++ b/supabase/migrations/20250930065243_empty_band.sql
@@ -171,7 +171,8 @@ alter table dispenses enable row level security;
 -- Policy is already created in 20250930060647_old_dream.sql; guard re-creation.
 do $$
 begin
-  if not exists (
+  -- Guard both table and policy creation for environments applying migrations in sequence.
+  if to_regclass('public.dispenses') is not null and not exists (
     select 1
     from pg_policies
     where schemaname = 'public'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,8 +25,10 @@ export default defineConfig(({ mode }) => {
     );
   }
 
+  const hasDefineReplacements = Object.keys(define).length > 0;
+
   return {
-    define,
+    ...(hasDefineReplacements ? { define } : {}),
     resolve: {
       alias: {
         "@": resolve(__dirname, "./src"),


### PR DESCRIPTION
### Motivation

- Prevent accidental hard-replacement of client `import.meta.env.VITE_SUPABASE_*` values at build time when `loadEnv()` may return empty values, which caused valid `.env` variables to be overridden with empty strings.
- Avoid migration failures caused by attempting to recreate an already-existing `dispenses` RLS policy when migrations are applied in sequence.

### Description

- Updated `vite.config.ts` to only include the `define` replacement object when there are actual fallback mappings by adding `const hasDefineReplacements = Object.keys(define).length > 0` and conditionally spreading `define` with `...(hasDefineReplacements ? { define } : {})` in the returned config.
- Hardened `supabase/migrations/20250930065243_empty_band.sql` by wrapping the policy creation in a `do $$ ... $$;` block that checks both table existence via `to_regclass('public.dispenses')` and policy absence in `pg_policies` before creating the `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cabcba448332b816eaf94622a575)