### PR TITLE
Fix Vite Supabase env injection regression in PR #15

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,21 +1,10 @@
-import { defineConfig, loadEnv } from "vite";
+import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import { resolve } from "path";
 
 export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), "");
-  const clientSupabaseUrl = env.VITE_SUPABASE_URL || env.SUPABASE_URL || "";
-  const clientSupabaseAnonKey =
-    env.VITE_SUPABASE_ANON_KEY || env.SUPABASE_ANON_KEY || "";
-
   return {
-    define: {
-      "import.meta.env.VITE_SUPABASE_URL": JSON.stringify(clientSupabaseUrl),
-      "import.meta.env.VITE_SUPABASE_ANON_KEY": JSON.stringify(
-        clientSupabaseAnonKey,
-      ),
-    },
     resolve: {
       alias: {
         "@": resolve(__dirname, "./src"),


### PR DESCRIPTION
### Motivation

- Fix a P1 regression where `vite.config.ts` was statically replacing `import.meta.env.VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`, which could bake empty strings into the client bundle and disable Supabase features instead of using Vite's runtime `import.meta.env` behavior.

### Description

- Removed the `loadEnv` usage and the `define` overrides from `vite.config.ts` so the client relies on Vite's native `import.meta.env` handling for `VITE_*` variables and no longer hardcodes potentially empty Supabase values.

### Testing

- Ran `npm run build` which completed successfully, and the commit pre-checks (including `eslint`, `prettier`, and `tsc-files --noEmit`) passed during the commit hook.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cc5db1a88332ab4ab48767f3d10e)