### PR TITLE
fix: fail addVisit when consultation insert is not persisted

### DIFF
--- a/src/services/patientService.ts
+++ b/src/services/patientService.ts
@@ -487,20 +487,25 @@ export async function addVisit(
   }
 
   if (hasConsultationContent) {
-    const { error: consultError } = await supabase.from("consultations").insert({
-      id: crypto.randomUUID(),
-      patient_id: patientId,
-      visit_id: visitId,
-      provider_name: "Staff (portal)",
-      soap_subjective: visit.notes ?? "",
-      soap_objective: "",
-      soap_assessment: visit.diagnosis ?? "",
-      soap_plan: "",
-      provisional_dx: [],
-    });
+    const { data: consultRow, error: consultError } = await supabase
+      .from("consultations")
+      .insert({
+        id: crypto.randomUUID(),
+        patient_id: patientId,
+        visit_id: visitId,
+        provider_name: "Staff (portal)",
+        soap_subjective: visit.notes ?? "",
+        soap_objective: "",
+        soap_assessment: visit.diagnosis ?? "",
+        soap_plan: "",
+        provisional_dx: [],
+      })
+      .select("id")
+      .single();
 
-    if (consultError) {
-      logger.error("[patientService] addVisit (consultation):", consultError.message);
+    if (consultError || !consultRow?.id) {
+      const consultFailureMessage = consultError?.message ?? "No consultation row was returned after insert";
+      logger.error("[patientService] addVisit (consultation):", consultFailureMessage);
 
       // Best-effort rollback to avoid reporting a successful visit when clinical
       // notes failed to persist.
@@ -518,13 +523,13 @@ export async function addVisit(
 
         return {
           data: null,
-          error: `Consultation save failed and visit cleanup failed: ${consultError.message}. Cleanup error: ${rollbackError.message}`,
+          error: `Consultation save failed and visit cleanup failed: ${consultFailureMessage}. Cleanup error: ${rollbackError.message}`,
         };
       }
 
       return {
         data: null,
-        error: `Consultation save failed; visit was rolled back: ${consultError.message}`,
+        error: `Consultation save failed; visit was rolled back: ${consultFailureMessage}`,
       };
     }
   }


### PR DESCRIPTION
### Motivation
- Prevent reporting a successful visit when the consultation row failed to persist, which can leave the system in an inconsistent state (visit exists but clinical note is missing).

### Description
- In `src/services/patientService.ts` updated `addVisit` to request the inserted consultation row via `.select("id").single()` and treat either a Supabase error or a missing returned row as a failure, logging a normalized `consultFailureMessage` and performing the existing best-effort rollback of the created visit.

### Testing
- Ran `npm run typecheck`, which failed due to pre-existing unrelated TypeScript/JSX syntax errors in other files, so full typecheck is not green; the change itself adds explicit insert verification and error paths in `addVisit`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cdafbfa48332a16c5c8d355bb765)