### PR TITLE
Follow-up: fix dispenses schema migration convergence for PR #42

### DIFF
--- a/supabase/migrations/20260420000000_add_inventory_nm_and_tickets.sql
+++ b/supabase/migrations/20260420000000_add_inventory_nm_and_tickets.sql
@@ -168,19 +168,50 @@ CREATE POLICY "Allow authenticated access to prescriptions"
   USING (true) WITH CHECK (true);
 
 -- ─────────────────────────────────────────────────────────────────────────────
--- dispenses already exists from 20250930060647_old_dream.sql; the table
--- creation is skipped by IF NOT EXISTS, but the policy must be dropped first.
+-- dispenses already exists from an earlier migration. Explicitly evolve the
+-- table shape here so upgraded and fresh databases converge on the same schema.
 
-CREATE TABLE IF NOT EXISTS dispenses (
-  id              text        PRIMARY KEY,
-  prescription_id text        NOT NULL REFERENCES prescriptions (id) ON DELETE CASCADE,
-  patient_id      text        NOT NULL,
-  item_id         text        NOT NULL REFERENCES pharmacy_items (id) ON DELETE RESTRICT,
-  batch_id        text        NOT NULL REFERENCES pharmacy_batches (id) ON DELETE RESTRICT,
-  qty             int         NOT NULL,
-  dispensed_by    text        NOT NULL,
-  dispensed_at    timestamptz NOT NULL DEFAULT now()
-);
+ALTER TABLE IF EXISTS dispenses
+  ADD COLUMN IF NOT EXISTS prescription_id text,
+  ADD COLUMN IF NOT EXISTS item_id text,
+  ADD COLUMN IF NOT EXISTS batch_id text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'dispenses_prescription_id_fkey'
+      AND conrelid = 'dispenses'::regclass
+  ) THEN
+    ALTER TABLE dispenses
+      ADD CONSTRAINT dispenses_prescription_id_fkey
+      FOREIGN KEY (prescription_id) REFERENCES prescriptions (id) ON DELETE CASCADE;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'dispenses_item_id_fkey'
+      AND conrelid = 'dispenses'::regclass
+  ) THEN
+    ALTER TABLE dispenses
+      ADD CONSTRAINT dispenses_item_id_fkey
+      FOREIGN KEY (item_id) REFERENCES pharmacy_items (id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'dispenses_batch_id_fkey'
+      AND conrelid = 'dispenses'::regclass
+  ) THEN
+    ALTER TABLE dispenses
+      ADD CONSTRAINT dispenses_batch_id_fkey
+      FOREIGN KEY (batch_id) REFERENCES pharmacy_batches (id) ON DELETE RESTRICT;
+  END IF;
+END
+$$;
 
 ALTER TABLE dispenses ENABLE ROW LEVEL SECURITY;
 


### PR DESCRIPTION
### Motivation
- The migration `supabase/migrations/20260420000000_add_inventory_nm_and_tickets.sql` previously used `CREATE TABLE IF NOT EXISTS dispenses (...)`, but `dispenses` is created earlier in the chain, so that block does not evolve the existing table and leaves legacy schema behind.
- The intent is to ensure both fresh and upgraded databases converge to the new schema (add `prescription_id`, `item_id`, `batch_id` and their FKs) without failing on re-runs.

### Description
- Replaced the `CREATE TABLE IF NOT EXISTS dispenses (...)` block with `ALTER TABLE IF EXISTS dispenses ADD COLUMN IF NOT EXISTS prescription_id`, `item_id`, and `batch_id` in `supabase/migrations/20260420000000_add_inventory_nm_and_tickets.sql`.
- Added a guarded `DO $$ ... $$` block that checks `pg_constraint` before creating each foreign-key constraint (`dispenses_prescription_id_fkey`, `dispenses_item_id_fkey`, `dispenses_batch_id_fkey`) to avoid errors on repeat runs.
- Kept the existing RLS and policy handling for `dispenses` intact after the schema-evolution steps.
- Committed the updated migration and opened a follow-up PR summarizing these changes.

### Testing
- Ran a repository-level static check by reviewing the migration diff with `git diff -- supabase/migrations/20260420000000_add_inventory_nm_and_tickets.sql`, which shows the `CREATE TABLE` block replaced by the additive `ALTER TABLE` and guarded FK logic (succeeded).
- Committed the change with `git commit -m "Fix dispenses migration to alter existing schema"` and created the follow-up PR (succeeded).
- No Postgres/Supabase instance was available in this environment to run the migration end-to-end, so runtime application of the migration was not executed; validation is based on static SQL review and constraint-guard logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5ce39de088332bf08013faab0c633)