### PR TITLE
Fix dispenses migration convergence in pharmacy inventory SQL

### DIFF
--- a/supabase/migrations/20260420000000_add_inventory_nm_and_tickets.sql
+++ b/supabase/migrations/20260420000000_add_inventory_nm_and_tickets.sql
@@ -171,7 +171,7 @@ CREATE POLICY "Allow authenticated access to prescriptions"
 -- dispenses already exists from an earlier migration. Explicitly evolve the
 -- table shape here so upgraded and fresh databases converge on the same schema.
 
-ALTER TABLE IF EXISTS dispenses
+ALTER TABLE dispenses
   ADD COLUMN IF NOT EXISTS prescription_id text,
   ADD COLUMN IF NOT EXISTS item_id text,
   ADD COLUMN IF NOT EXISTS batch_id text;


### PR DESCRIPTION
### Motivation
- Ensure the migration actually evolves the pre-existing `dispenses` table so upgraded and fresh databases converge on the same schema instead of silently skipping updates.

### Description
- Change `ALTER TABLE IF EXISTS dispenses` to `ALTER TABLE dispenses` in `supabase/migrations/20260420000000_add_inventory_nm_and_tickets.sql` while keeping the `ADD COLUMN IF NOT EXISTS` and conditional FK-creation logic intact.

### Testing
- Ran `git diff --check` and inspected the migration diff to confirm only the `dispenses` evolution line changed, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cf7c4e308332a953e94ac8daba55)