### PR TITLE
Follow-up: Only skip validation errors in duplicate scan

### DIFF
--- a/src/services/conflictQueue.ts
+++ b/src/services/conflictQueue.ts
@@ -154,13 +154,6 @@ function getFieldPHISensitivity(field: string): PHISensitivity {
   return PHI_FIELDS[field] || "none";
 }
 
-class InvalidDuplicateScanPatientError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "InvalidDuplicateScanPatientError";
-  }
-}
-
 function calculateOverallPHISensitivity(
   fields: ConflictField[],
 ): PHISensitivity {
@@ -803,11 +796,9 @@ export class ConflictQueueService {
       try {
         const dob = new Date(patient.dob);
         const hasValidDob = Number.isFinite(dob.getTime());
-        if (!hasValidDob || !patient.givenName || !patient.familyName) {
-          throw new InvalidDuplicateScanPatientError(
-            "Patient record is missing required duplicate-scan fields",
         const hasGivenName = Boolean(patient.givenName);
         const hasFamilyName = Boolean(patient.familyName);
+
         if (!hasValidDob || !hasGivenName || !hasFamilyName) {
           throw new DuplicateScanValidationError(
             "Invalid duplicate-scan patient data",
@@ -851,13 +842,6 @@ export class ConflictQueueService {
           }
         }
       } catch (error) {
-        if (error instanceof InvalidDuplicateScanPatientError) {
-          skippedRecords++;
-          logger.warn("Skipping patient with invalid duplicate-scan data", {
-            patientId: patient.id,
-            hasValidDob: Number.isFinite(new Date(patient.dob).getTime()),
-            hasGivenName: Boolean(patient.givenName),
-            hasFamilyName: Boolean(patient.familyName),
         if (error instanceof DuplicateScanValidationError) {
           skippedRecords++;
           logger.warn("Skipping patient with invalid duplicate-scan data", {


### PR DESCRIPTION
### Motivation
- Ensure duplicate-scanning doesn't hide operational or DB/runtime failures by only treating record-validation problems as skips; used the `supabase` skill because the fix touches Supabase/database-related scan behavior.

### Description
- Updated `scanForDuplicates` in `src/services/conflictQueue.ts` so that only `DuplicateScanValidationError` increments `skipped`, removed the broader invalid-error path that could classify operational failures as skips, and preserved rethrowing of non-validation/runtime errors so scan health surfaces real failures.

### Testing
- Ran the automated test suite with `npm test` (Vitest) and all tests passed (`270` tests passed); pre-commit hooks (`eslint --fix`, `prettier --write`, `tsc-files --noEmit`) ran during the commit and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cf507db88332aa8bb232a4a0205e)