### PR TITLE
[Follow-up to #44] Restore text-compatible sender/FK types in Supabase migrations

### DIFF
--- a/supabase/migrations/20251028000000_add_patient_portal.sql
+++ b/supabase/migrations/20251028000000_add_patient_portal.sql
@@ -417,7 +417,7 @@ CREATE POLICY "Patients can send messages"
       SELECT patient_id FROM patient_portal_users WHERE id = auth.uid()
     )
     AND sender_type = 'patient'
-    AND sender_id = auth.uid()
+    AND sender_id = auth.uid()::text
   );
 
 CREATE POLICY "Patients can update own messages"
@@ -451,7 +451,7 @@ CREATE POLICY "Staff can send messages to patients"
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
     AND sender_type = 'staff'
-    AND sender_id = auth.uid()
+    AND sender_id = auth.uid()::text
   );
 
 -- ============================================================================

--- a/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
+++ b/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
@@ -79,7 +79,7 @@ CREATE TABLE IF NOT EXISTS conflict_resolutions (
 -- Conflict Audit Logs Table (append-only for compliance)
 CREATE TABLE IF NOT EXISTS conflict_audit_logs (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  conflict_id uuid NOT NULL REFERENCES conflict_resolutions(id) ON DELETE CASCADE,
+  conflict_id text NOT NULL REFERENCES conflict_resolutions(id) ON DELETE CASCADE,
   action text NOT NULL CHECK (action IN ('created', 'viewed', 'resolved', 'approved', 'rejected', 'appealed', 'auto_resolved')),
   actor_id uuid REFERENCES auth.users(id),
   actor_role text,

--- a/supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql
+++ b/supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql
@@ -35,7 +35,7 @@
 -- Create conflict_change_deltas table for granular field tracking
 CREATE TABLE IF NOT EXISTS conflict_change_deltas (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  conflict_id uuid NOT NULL REFERENCES conflict_resolutions(id) ON DELETE CASCADE,
+  conflict_id text NOT NULL REFERENCES conflict_resolutions(id) ON DELETE CASCADE,
   field_name text NOT NULL,
   old_value jsonb,
   new_value jsonb,


### PR DESCRIPTION
### Motivation
- Fix migration replay failures caused by text/UUID type mismatches that break `CREATE POLICY` predicates and foreign key constraints during a fresh or replayed migration run.
- Earlier migrations create `patient_messages.sender_id` and `conflict_resolutions.id` as `text`, so later changes must remain compatible with those types to avoid `text = uuid` comparisons and invalid FK references.

### Description
- Restored `auth.uid()::text` casts for sender checks in patient messages INSERT policies in `supabase/migrations/20251028000000_add_patient_portal.sql` (both the "Patients can send messages" and "Staff can send messages to patients" policies).
- Reverted `conflict_id` column types to `text NOT NULL REFERENCES conflict_resolutions(id)` in `supabase/migrations/20260125094038_add_conflict_resolution_system.sql` (`conflict_audit_logs.conflict_id`).
- Reverted `conflict_id` column types to `text NOT NULL REFERENCES conflict_resolutions(id)` in `supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql` (`conflict_change_deltas.conflict_id`).

### Testing
- Ran `rg` to confirm the presence of `sender_id = auth.uid()::text` and `conflict_id text NOT NULL REFERENCES conflict_resolutions(id)` in the updated migration files and the matches were found.
- Ran `git diff --check` which reported no patch/whitespace issues and returned clean.
- Attempted `supabase --version` for CLI validation but the Supabase CLI was not installed in this environment (`command not found`), so full runtime migration application was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d0625f2c8332b3d346ac8eb3566c)