### PR TITLE
[Follow-up] Block auth_uid takeover when linking existing patients

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -111,6 +111,23 @@ export function useAuth(): UseAuthReturn {
         if (normPhone) orClauses.push(`phone.eq.${normPhone}`);
       }
 
+      // Security guard: never rebind a patient that already belongs to
+      // another auth user, even if their phone/email is matched at sign-up.
+      const { data: linkedPatient } = await supabase
+        .from("patients")
+        .select("id")
+        .or(orClauses.join(","))
+        .not("auth_uid", "is", null)
+        .neq("auth_uid", authData.user.id)
+        .maybeSingle();
+
+      if (linkedPatient) {
+        return {
+          message:
+            "We could not automatically link your clinic profile. Please contact support for identity verification.",
+        };
+      }
+
       const { data: existingPatient } = await supabase
         .from("patients")
         .select("id, auth_uid, dob")


### PR DESCRIPTION
### Motivation
- Prevent a high-priority account takeover vector where a new registrant could rebind an existing patient row by matching phone/email and overwrite its `auth_uid`.
- Ensure auto-linking only occurs for truly unlinked patient rows and retain additional identity checks (DOB/OTP) as recommended for stronger proof.

### Description
- Added a pre-link security check in `src/hooks/useAuth.ts` that queries for any matching patient (by email/phone) already linked to a different `auth_uid` and refuses auto-linking if found.
- When a conflicting linked patient is detected the signup now returns a verification-required error message instead of reassigning `auth_uid`.
- Kept the existing DOB verification and the race-safe conditional update that only updates rows where `.is('auth_uid', null)` so only unclaimed rows can be claimed.

### Testing
- Ran `npm run typecheck` which completed successfully with no TypeScript errors.
- Ran `npm run lint` which still fails due to pre-existing, repository-wide lint errors unrelated to this change.
- No new unit tests were added for this small auth-guard change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5cfe5d6e4833298439b2ab06031ff)