### PR TITLE
Fix migration UUID mismatches flagged in PR #40 review

### DIFF
--- a/supabase/migrations/20251028000000_add_patient_portal.sql
+++ b/supabase/migrations/20251028000000_add_patient_portal.sql
@@ -417,7 +417,7 @@ CREATE POLICY "Patients can send messages"
       SELECT patient_id FROM patient_portal_users WHERE id = auth.uid()
     )
     AND sender_type = 'patient'
-    AND sender_id = auth.uid()
+    AND sender_id = auth.uid()::uuid
   );
 
 CREATE POLICY "Patients can update own messages"
@@ -451,7 +451,7 @@ CREATE POLICY "Staff can send messages to patients"
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
     AND sender_type = 'staff'
-    AND sender_id = auth.uid()
+    AND sender_id = auth.uid()::uuid
   );
 
 -- ============================================================================

--- a/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
+++ b/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
@@ -89,6 +89,10 @@ CREATE TABLE IF NOT EXISTS conflict_audit_logs (
   created_at timestamptz NOT NULL DEFAULT now()
 );
 
+-- Ensure FK column stays UUID-compatible with conflict_resolutions.id
+ALTER TABLE conflict_audit_logs
+  ALTER COLUMN conflict_id TYPE uuid USING conflict_id::uuid;
+
 -- Auto Resolution Rules Table
 CREATE TABLE IF NOT EXISTS auto_resolution_rules (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql
+++ b/supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql
@@ -46,6 +46,10 @@ CREATE TABLE IF NOT EXISTS conflict_change_deltas (
   created_at timestamptz DEFAULT now()
 );
 
+-- Ensure FK column stays UUID-compatible with conflict_resolutions.id
+ALTER TABLE conflict_change_deltas
+  ALTER COLUMN conflict_id TYPE uuid USING conflict_id::uuid;
+
 COMMENT ON TABLE conflict_change_deltas IS 'Indefinite retention of field-level changes for AI training and compliance audits';
 COMMENT ON COLUMN conflict_change_deltas.phi_field IS 'Whether this field contains Protected Health Information';
 COMMENT ON COLUMN conflict_change_deltas.change_type IS 'Type of change: merge (combined values), override (replaced), correction (fixed error), auto_resolve (system decision)';


### PR DESCRIPTION
### Motivation

- Prevent migration failures caused by incompatible UUID/text comparisons in RLS policies and mismatched FK column types referencing `conflict_resolutions(id)` in new conflict-resolution tables.

### Description

- Cast `auth.uid()` to UUID in patient message RLS insert checks by changing `AND sender_id = auth.uid()` to `AND sender_id = auth.uid()::uuid` in `supabase/migrations/20251028000000_add_patient_portal.sql` to avoid `uuid = text` comparisons. 
- Ensure `conflict_audit_logs.conflict_id` is UUID-compatible by adding `ALTER TABLE conflict_audit_logs ALTER COLUMN conflict_id TYPE uuid USING conflict_id::uuid;` in `supabase/migrations/20260125094038_add_conflict_resolution_system.sql` so the FK aligns with `conflict_resolutions(id)`.
- Ensure `conflict_change_deltas.conflict_id` is UUID-compatible by adding `ALTER TABLE conflict_change_deltas ALTER COLUMN conflict_id TYPE uuid USING conflict_id::uuid;` in `supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql` so the FK aligns with `conflict_resolutions(id)`.

### Testing

- Ran repository checks with `rg` to verify the `auth.uid()::uuid` casts and `ALTER COLUMN ... TYPE uuid USING ...` lines are present and they succeeded. 
- Inspected the migration diff with `git diff` to confirm the intended SQL changes were applied and the diff matched the expected edits. 
- Attempted `supabase --version` but it failed in this environment (`supabase: command not found`), so `supabase db push` / end-to-end migration execution could not be run here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d0e645d883329516b1469adb07f8)