### PR TITLE
[Follow-up] Prevent unsafe patient auth_uid reassignment in portal signup

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -111,22 +111,29 @@ export function useAuth(): UseAuthReturn {
         if (normPhone) orClauses.push(`phone.eq.${normPhone}`);
       }
 
+      const normalizedEmail = data.email.toLowerCase().trim();
+
       const { data: existingPatient } = await supabase
         .from("patients")
-        .select("id, auth_uid, dob")
+        .select("id, auth_uid, dob, email, phone")
         .or(orClauses.join(","))
         .is("auth_uid", null)
         .maybeSingle();
 
       if (existingPatient) {
-        // Verify DOB when both sides have it — prevents linking via phone alone.
-        if (
-          existingPatient.dob &&
-          data.dob &&
-          existingPatient.dob !== data.dob
-        ) {
-          // DOB mismatch: don't link; create a fresh row instead.
-        } else {
+        const normalizedPhone = data.phone ? normalizePhone(data.phone) : null;
+        const matchedByEmail =
+          !!existingPatient.email &&
+          existingPatient.email.toLowerCase().trim() === normalizedEmail;
+        const matchedByPhone =
+          !!normalizedPhone && existingPatient.phone === normalizedPhone;
+        const dobMatches =
+          !!existingPatient.dob &&
+          !!data.dob &&
+          existingPatient.dob === data.dob;
+        const canLinkPatient = matchedByEmail || (matchedByPhone && dobMatches);
+
+        if (canLinkPatient) {
           // Conditional update: only succeeds if auth_uid is still NULL (race safety).
           const { error: linkError } = await supabase
             .from("patients")


### PR DESCRIPTION
### Motivation
- Fix a P1 issue where a new registrant could rebind an existing patient row (matched by phone) to their account and expose another patient’s records. 
- Strengthen identity checks during signup so linking only occurs with sufficient proof of identity. 
- Preserve race-safety and the existing guard that prevents overwriting already-linked rows.

### Description
- Updated `src/hooks/useAuth.ts` to fetch `email` and `phone` for explicit verification before linking a patient row. 
- Added normalized-email/phone and DOB comparison logic and only permit linking when there is an exact email match or a phone match combined with a DOB match. 
- Kept the conditional update using `.is("auth_uid", null)` so an update cannot overwrite an existing `auth_uid` (race-safe), and fall back to inserting a fresh patient row when criteria are not met.

### Testing
- Ran `npm run typecheck`, which completed successfully. 
- Ran `npm run lint`, which failed due to numerous pre-existing repository lint errors unrelated to this change; the change itself is type-safe per the typecheck run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d231dbac8332bb7ad694e8dc59cc)