### PR TITLE
Follow-up: fix UUID policy/FK mismatches in patient portal + conflict migrations

### DIFF
--- a/supabase/migrations/20251028000000_add_patient_portal.sql
+++ b/supabase/migrations/20251028000000_add_patient_portal.sql
@@ -417,7 +417,7 @@ CREATE POLICY "Patients can send messages"
       SELECT patient_id FROM patient_portal_users WHERE id = auth.uid()
     )
     AND sender_type = 'patient'
-    AND sender_id = auth.uid()::uuid
+    AND sender_id = auth.uid()
   );
 
 CREATE POLICY "Patients can update own messages"
@@ -451,7 +451,7 @@ CREATE POLICY "Staff can send messages to patients"
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
     AND sender_type = 'staff'
-    AND sender_id = auth.uid()::uuid
+    AND sender_id = auth.uid()
   );
 
 -- ============================================================================

--- a/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
+++ b/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
@@ -89,10 +89,6 @@ CREATE TABLE IF NOT EXISTS conflict_audit_logs (
   created_at timestamptz NOT NULL DEFAULT now()
 );
 
--- Ensure FK column stays UUID-compatible with conflict_resolutions.id
-ALTER TABLE conflict_audit_logs
-  ALTER COLUMN conflict_id TYPE uuid USING conflict_id::uuid;
-
 -- Auto Resolution Rules Table
 CREATE TABLE IF NOT EXISTS auto_resolution_rules (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -112,8 +108,8 @@ CREATE TABLE IF NOT EXISTS auto_resolution_rules (
 
 -- Add columns to conflict_resolutions if created by earlier migration without them
 ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS entity_type text;
-ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS entity_id text;
-ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS priority integer NOT NULL DEFAULT 5;
+ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS entity_id uuid;
+ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS priority text NOT NULL DEFAULT 'medium';
 
 -- Indexes for performance
 CREATE INDEX IF NOT EXISTS idx_conflict_resolutions_status ON conflict_resolutions(status);

--- a/supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql
+++ b/supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql
@@ -46,10 +46,6 @@ CREATE TABLE IF NOT EXISTS conflict_change_deltas (
   created_at timestamptz DEFAULT now()
 );
 
--- Ensure FK column stays UUID-compatible with conflict_resolutions.id
-ALTER TABLE conflict_change_deltas
-  ALTER COLUMN conflict_id TYPE uuid USING conflict_id::uuid;
-
 COMMENT ON TABLE conflict_change_deltas IS 'Indefinite retention of field-level changes for AI training and compliance audits';
 COMMENT ON COLUMN conflict_change_deltas.phi_field IS 'Whether this field contains Protected Health Information';
 COMMENT ON COLUMN conflict_change_deltas.change_type IS 'Type of change: merge (combined values), override (replaced), correction (fixed error), auto_resolve (system decision)';


### PR DESCRIPTION
### Motivation
- Migrations were failing on fresh environments due to UUID/text type mismatches in RLS checks and foreign key columns which block `supabase db push` and break the migration chain.
- RLS policies compared `patient_messages.sender_id` (uuid) to `auth.uid()` with incompatible casts, and two conflict-related tables had FK/PK type inconsistencies with `conflict_resolutions.id` (uuid).

### Description
- Updated `patient_messages` INSERT policies to compare `sender_id` directly against `auth.uid()` (UUID-to-UUID) instead of using fragile casts; changes are in `supabase/migrations/20251028000000_add_patient_portal.sql`.
- Removed the redundant `ALTER TABLE ... ALTER COLUMN conflict_id TYPE uuid USING conflict_id::uuid;` conversions from conflict migrations so the FK is created as `uuid` at table creation; changes are in `supabase/migrations/20260125094038_add_conflict_resolution_system.sql` and `supabase/migrations/20260125095109_add_conflict_delta_retention_and_archiving.sql`.
- Aligned fallback `ADD COLUMN IF NOT EXISTS` definitions in the conflict system so `entity_id` is `uuid` and `priority` is `text NOT NULL DEFAULT 'medium'` to maintain type compatibility with existing UUID PKs.

### Testing
- Inspected the updated SQL with `git diff` and file excerpts via `nl`/`sed` to confirm the `sender_id = auth.uid()` changes and that `conflict_id`/`conflict_resolutions` FK types are UUID-consistent, and these checks succeeded.
- Searched relevant patterns with `rg` to verify no remaining `sender_id = auth.uid()::uuid` or `conflict_id text` FK patterns remain, and the search returned no problematic matches. 
- Committed the changes with `git commit` and created the follow-up PR; the commit succeeded and the new PR was prepared.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d9633d4483329ce25765ddad2032)