### PR TITLE
Restore SUPABASE_* fallback in Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,21 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import { resolve } from "path";
 
 export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+
+  // Keep Vercel/Supabase integration compatibility: when only SUPABASE_*
+  // vars are present, promote them to VITE_* so existing client code using
+  // import.meta.env.VITE_SUPABASE_* continues to work without define overrides.
+  if (!process.env.VITE_SUPABASE_URL && env.SUPABASE_URL) {
+    process.env.VITE_SUPABASE_URL = env.SUPABASE_URL;
+  }
+  if (!process.env.VITE_SUPABASE_ANON_KEY && env.SUPABASE_ANON_KEY) {
+    process.env.VITE_SUPABASE_ANON_KEY = env.SUPABASE_ANON_KEY;
+  }
+
   return {
     resolve: {
       alias: {


### PR DESCRIPTION
### Motivation

- A P1 regression caused by removing `loadEnv` and the SUPABASE -> VITE_* fallback resulted in client builds missing `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` when only `SUPABASE_URL` / `SUPABASE_ANON_KEY` were provided (e.g., Vercel Supabase integration). 
- Ensure the app ships usable Supabase credentials in environments that expose only non-`VITE_` variables without reintroducing hardcoded `define` replacements.

### Description

- Reintroduced `loadEnv` in `vite.config.ts` and read envs with `loadEnv(mode, process.cwd(), "")` so build-time env values are available. 
- Added process-level fallback promotion that sets `process.env.VITE_SUPABASE_URL` from `env.SUPABASE_URL` when the `VITE_` var is missing. 
- Added the same promotion for `process.env.VITE_SUPABASE_ANON_KEY` from `env.SUPABASE_ANON_KEY`. 
- Kept Vite's native `import.meta.env` behavior and avoided `define` overrides so values are not hardcoded into the bundle.

### Testing

- Ran `npm run build` which completed successfully. 
- Pre-commit checks passed during the change (`eslint --fix`, `prettier --write`, and `tsc-files --noEmit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5d8e077c08332b0b022be850c258a)