### PR TITLE
fix: restore SUPABASE_* fallback mapping in Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,26 @@
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 import { resolve } from "path";
 
 export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+  const define: Record<string, string> = {};
+
+  if (!env.VITE_SUPABASE_URL && env.SUPABASE_URL) {
+    define["import.meta.env.VITE_SUPABASE_URL"] = JSON.stringify(
+      env.SUPABASE_URL,
+    );
+  }
+
+  if (!env.VITE_SUPABASE_ANON_KEY && env.SUPABASE_ANON_KEY) {
+    define["import.meta.env.VITE_SUPABASE_ANON_KEY"] = JSON.stringify(
+      env.SUPABASE_ANON_KEY,
+    );
+  }
+
   return {
+    ...(Object.keys(define).length ? { define } : {}),
     resolve: {
       alias: {
         "@": resolve(__dirname, "./src"),


### PR DESCRIPTION
### Motivation

- A previous change removed `loadEnv` and the fallback mapping, causing builds to ignore `SUPABASE_URL`/`SUPABASE_ANON_KEY` when only the non-`VITE_` envs are provided (e.g., many Vercel Supabase integrations), which can bake missing Supabase credentials into the client bundle.  
- The intent is to restore a safe fallback so the client receives Supabase values when `VITE_*` vars are not set while avoiding overrides when `VITE_*` are present.

### Description

- Reintroduced `loadEnv` from Vite and read the full env set during config evaluation.  
- Added a conditional `define` mapping that injects `import.meta.env.VITE_SUPABASE_URL` and `import.meta.env.VITE_SUPABASE_ANON_KEY` from `SUPABASE_URL`/`SUPABASE_ANON_KEY` only when the `VITE_*` equivalents are missing.  
- The `define` object is merged into the returned config only when it contains entries, leaving default Vite `import.meta.env` behavior unchanged otherwise.

### Testing

- Ran `npm run build`, which completed successfully.  
- Pre-commit checks ran and passed during the commit, including `eslint --fix`, `prettier --write`, and `tsc-files --noEmit`.  
- Build artifacts were produced as part of the successful production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5da9a994c83329b28e82c0a2ab018)