### PR TITLE
fix: unblock Vercel builds and restore Medical History + Messages

### DIFF
--- a/src/features/patient-portal/PatientLogin.tsx
+++ b/src/features/patient-portal/PatientLogin.tsx
@@ -6,7 +6,8 @@ import { z } from "zod";
 import { ArrowRightIcon, ShieldCheckIcon } from "@heroicons/react/24/outline";
 import { useAuth } from "@/hooks/useAuth";
 import { loginPatientPortal } from "@/services/patientPortalAuth";
-import { isSupabaseEnabled } from "@/lib/supabaseClient";
+import { supabase, isSupabaseEnabled } from "@/lib/supabaseClient";
+import { getPatientProfile } from "@/services/patientService";
 
 const onlineSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
@@ -58,6 +59,26 @@ export function PatientLogin() {
         setError(authError.message);
       }
       return;
+    }
+    // Populate patient_portal_user so Medical History / Messages can find the patient ID
+    if (supabase) {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (user) {
+          const profileRes = await getPatientProfile(user.id);
+          if (profileRes.data) {
+            localStorage.setItem("patient_portal_user", JSON.stringify({
+              id: user.id,
+              patientId: profileRes.data.id,
+              givenName: profileRes.data.givenName,
+              familyName: profileRes.data.familyName,
+              email: profileRes.data.email,
+            }));
+          }
+        }
+      } catch {
+        // Non-fatal: Medical History / Messages will show an error if patientId is missing
+      }
     }
     navigate("/patient/dashboard");
   };

--- a/src/features/patient-portal/PatientRegister.tsx
+++ b/src/features/patient-portal/PatientRegister.tsx
@@ -10,7 +10,8 @@ import {
 } from "@heroicons/react/24/outline";
 import { useAuth } from "@/hooks/useAuth";
 import { registerPatientPortalAccount } from "@/services/patientPortalAuth";
-import { isSupabaseEnabled } from "@/lib/supabaseClient";
+import { supabase, isSupabaseEnabled } from "@/lib/supabaseClient";
+import { getPatientProfile } from "@/services/patientService";
 
 // Online: password-based auth via Supabase
 const onlineSchema = z
@@ -87,11 +88,6 @@ export function PatientRegister() {
       password:   data.password,
       givenName,
       familyName,
-      phone:      data.phone        || undefined,
-      dob:        data.dateOfBirth  || undefined,
-      password:   (data as z.infer<typeof onlineSchema>).password,
-      givenName,
-      familyName,
       phone:      data.phone       || undefined,
       dob:        data.dateOfBirth || undefined,
     });
@@ -103,6 +99,26 @@ export function PatientRegister() {
         setError(authError.message);
       }
       return;
+    }
+    // Populate patient_portal_user so Medical History / Messages can find the patient ID
+    if (supabase) {
+      try {
+        const { data: { user } } = await supabase.auth.getUser();
+        if (user) {
+          const profileRes = await getPatientProfile(user.id);
+          if (profileRes.data) {
+            localStorage.setItem("patient_portal_user", JSON.stringify({
+              id: user.id,
+              patientId: profileRes.data.id,
+              givenName: profileRes.data.givenName,
+              familyName: profileRes.data.familyName,
+              email: profileRes.data.email,
+            }));
+          }
+        }
+      } catch {
+        // Non-fatal: Medical History / Messages will show an error if patientId is missing
+      }
     }
     setStep("success");
     setTimeout(() => navigate("/patient/dashboard"), 1800);


### PR DESCRIPTION
## Summary

- **Fix Vercel build failures** — every recent production deployment was erroring with 84 TypeScript syntax errors caused by repeated bad merges into `mainone` leaving both sides of resolved conflicts in five files. Restored each file to its last clean non-merge commit.
- **Fix Medical History and Messages tabs** — when Supabase Auth is enabled, login/register never wrote `patient_portal_user` to localStorage. Both `MedicalHistory` and `SecureMessaging` read `patientId` from that key and immediately redirected to `/patient/login`, making both tabs non-functional for any Supabase-authenticated patient.

## Changes

### Commit `641f770` — merge-conflict cleanup
Restored 5 files to their last clean non-merge commits (84 TS errors → 2 pre-existing config notices):

| File | Restored to |
|------|-------------|
| `src/features/doctor/PatientMessagesPanel.tsx` | `0bc1bfa` |
| `src/features/patient-portal/PatientLogin.tsx` | `0bc1bfa` |
| `src/hooks/useAuth.ts` | `f543383` |
| `src/services/conflictQueue.ts` | `0bc1bfa` |
| `src/services/patientService.ts` | `542346d` *(preserves addVisit consultation rollback fix)* |

### Commit `80fd161` — patient portal auth fix
After a successful Supabase login or signup, fetch the patient row via `getPatientProfile(user.id)` and store `{ id, patientId, givenName, familyName, email }` in localStorage under `patient_portal_user`. Also removed duplicate object properties left from a prior bad merge in `PatientRegister.handleSupabaseRegister`.

## Test plan

- [ ] Verify Vercel preview deployment for this PR builds successfully (green)
- [ ] Log in as a patient via Supabase Auth → click **Medical History** → page loads (no redirect to login)
- [ ] Log in as a patient via Supabase Auth → click **Messages** → page loads (no redirect to login)
- [ ] Offline mode (no Supabase env vars) → existing localStorage-based login still works

https://claude.ai/code/session_01DcuSXEH3yL2o1wb6skFREs