### PR TITLE
Harden dispenses schema convergence checks in migration

### DIFF
--- a/supabase/migrations/20260420000000_add_inventory_nm_and_tickets.sql
+++ b/supabase/migrations/20260420000000_add_inventory_nm_and_tickets.sql
@@ -180,9 +180,14 @@ DO $$
 BEGIN
   IF NOT EXISTS (
     SELECT 1
-    FROM pg_constraint
-    WHERE conname = 'dispenses_prescription_id_fkey'
-      AND conrelid = 'dispenses'::regclass
+    FROM pg_constraint c
+    JOIN pg_attribute a
+      ON a.attrelid = c.conrelid
+     AND a.attnum = ANY (c.conkey)
+    WHERE c.contype = 'f'
+      AND c.conrelid = 'dispenses'::regclass
+      AND a.attname = 'prescription_id'
+      AND c.confrelid = 'prescriptions'::regclass
   ) THEN
     ALTER TABLE dispenses
       ADD CONSTRAINT dispenses_prescription_id_fkey
@@ -191,9 +196,14 @@ BEGIN
 
   IF NOT EXISTS (
     SELECT 1
-    FROM pg_constraint
-    WHERE conname = 'dispenses_item_id_fkey'
-      AND conrelid = 'dispenses'::regclass
+    FROM pg_constraint c
+    JOIN pg_attribute a
+      ON a.attrelid = c.conrelid
+     AND a.attnum = ANY (c.conkey)
+    WHERE c.contype = 'f'
+      AND c.conrelid = 'dispenses'::regclass
+      AND a.attname = 'item_id'
+      AND c.confrelid = 'pharmacy_items'::regclass
   ) THEN
     ALTER TABLE dispenses
       ADD CONSTRAINT dispenses_item_id_fkey
@@ -202,9 +212,14 @@ BEGIN
 
   IF NOT EXISTS (
     SELECT 1
-    FROM pg_constraint
-    WHERE conname = 'dispenses_batch_id_fkey'
-      AND conrelid = 'dispenses'::regclass
+    FROM pg_constraint c
+    JOIN pg_attribute a
+      ON a.attrelid = c.conrelid
+     AND a.attnum = ANY (c.conkey)
+    WHERE c.contype = 'f'
+      AND c.conrelid = 'dispenses'::regclass
+      AND a.attname = 'batch_id'
+      AND c.confrelid = 'pharmacy_batches'::regclass
   ) THEN
     ALTER TABLE dispenses
       ADD CONSTRAINT dispenses_batch_id_fkey


### PR DESCRIPTION
### Motivation
- The migration should evolve the existing `dispenses` table instead of relying on `CREATE TABLE IF NOT EXISTS`, so upgraded and fresh databases converge on the same schema.
- Foreign-key existence checks must be semantic (column + referenced table) rather than brittle constraint-name checks so the migration is idempotent across environments where FK names may differ.

### Description
- Ensure the migration explicitly uses `ALTER TABLE dispenses ADD COLUMN IF NOT EXISTS prescription_id, item_id, batch_id` to converge the table shape.
- Replace simple `pg_constraint` name checks with a semantic guard that joins `pg_constraint` and `pg_attribute` and verifies `contype = 'f'`, the constrained column name (e.g., `prescription_id`) and the referenced table (`confrelid = 'prescriptions'::regclass`) before adding each FK.
- Constraints are still added with the same names (`dispenses_prescription_id_fkey`, `dispenses_item_id_fkey`, `dispenses_batch_id_fkey`) and the original `ON DELETE` behaviors are preserved.
- The migration remains idempotent and more robust to differences in FK naming across environments.

### Testing
- Inspected the migration file with `sed -n '1,260p' supabase/migrations/20260420000000_add_inventory_nm_and_tickets.sql` and `nl -ba ... | sed -n '165,235p'` to verify the change, and both commands succeeded.
- Applied the automated edit via a Python script and validated the diff with `git diff -- supabase/migrations/20260420000000_add_inventory_nm_and_tickets.sql`, and the change was committed successfully with `git commit -m "Harden dispenses FK migration checks"`.
- No runtime or database migration execution tests were run in this environment, so DB-level validation is still recommended during deployment or in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5dc928bac83328d8585042634880a)