### PR TITLE
Fix legacy conflict_resolutions entity_id fallback to text for upgrade compatibility

### DIFF
--- a/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
+++ b/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
@@ -108,7 +108,8 @@ CREATE TABLE IF NOT EXISTS auto_resolution_rules (
 
 -- Add columns to conflict_resolutions if created by earlier migration without them
 ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS entity_type text;
-ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS entity_id uuid;
+-- Keep fallback column text-typed for compatibility with legacy conflict rows tied to text PKs.
+ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS entity_id text;
 ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS priority text NOT NULL DEFAULT 'medium';
 
 -- Indexes for performance


### PR DESCRIPTION
### Motivation
- Prevent runtime insert failures on upgrade paths where older migrations and tables use text-backed record IDs by avoiding adding a `uuid`-typed fallback column that rejects non-UUID IDs.

### Description
- Replaced `ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS entity_id uuid;` with `ALTER TABLE conflict_resolutions ADD COLUMN IF NOT EXISTS entity_id text;` in `supabase/migrations/20260125094038_add_conflict_resolution_system.sql` and added an inline comment explaining the legacy compatibility reason, while leaving the fresh-create `entity_id uuid NOT NULL` definition unchanged.

### Testing
- Confirmed the change with file inspection (`nl`) and pattern searches (`rg`) to verify the fallback now uses `text` and the primary table still defines `entity_id` as `uuid`, and these automated checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5dcc5592c8332ac59f0072a43effb)