### PR TITLE
Fail closed on linked-patient lookup errors during signup

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -113,13 +113,20 @@ export function useAuth(): UseAuthReturn {
 
       // Security guard: never rebind a patient that already belongs to
       // another auth user, even if their phone/email is matched at sign-up.
-      const { data: linkedPatient } = await supabase
+      const { data: linkedPatient, error: linkedPatientError } = await supabase
         .from("patients")
         .select("id")
         .or(orClauses.join(","))
         .not("auth_uid", "is", null)
         .neq("auth_uid", authData.user.id)
         .maybeSingle();
+
+      if (linkedPatientError) {
+        return {
+          message:
+            "We could not automatically verify your clinic profile. Please contact support for identity verification.",
+        };
+      }
 
       if (linkedPatient) {
         return {


### PR DESCRIPTION
### Motivation
- Prevent a fail-open path during signup where `maybeSingle()` lookup errors (multi-row matches or transient DB errors) could allow auto-linking and reassigning an `auth_uid`, reintroducing an account-takeover vector.

### Description
- Captures the query `error` from the linked-patient lookup in `src/hooks/useAuth.ts` and fails closed when an error occurs by returning a verification-required message instead of continuing.
- Retains the existing `if (linkedPatient)` guard so known already-linked matches still block auto-linking and require support verification.
- Leaves downstream behavior intact: conditional `UPDATE` to claim truly unlinked rows and insertion of a fresh patient row when no safe match is found.
- Change localized to the signup flow in `useAuth.signup` and only adds an explicit error-check for the linked-patient query.

### Testing
- Ran `npm run typecheck` which completed successfully with no TypeScript errors.
- Ran `npm run lint`, which failed due to pre-existing repository-wide lint errors unrelated to this change.
- No new unit tests were added for this small auth-guard change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5de8b35948332b261a32326dc83c8)