### PR TITLE
[Follow-up to #57] Harden linked-patient guard against query edge cases

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -113,13 +113,13 @@ export function useAuth(): UseAuthReturn {
 
       // Security guard: never rebind a patient that already belongs to
       // another auth user, even if their phone/email is matched at sign-up.
-      const { data: linkedPatient, error: linkedPatientError } = await supabase
+      const { data: linkedPatients, error: linkedPatientError } = await supabase
         .from("patients")
         .select("id")
         .or(orClauses.join(","))
         .not("auth_uid", "is", null)
         .neq("auth_uid", authData.user.id)
-        .maybeSingle();
+        .limit(1);
 
       if (linkedPatientError) {
         return {
@@ -128,7 +128,7 @@ export function useAuth(): UseAuthReturn {
         };
       }
 
-      if (linkedPatient) {
+      if (linkedPatients && linkedPatients.length > 0) {
         return {
           message:
             "We could not automatically link your clinic profile. Please contact support for identity verification.",


### PR DESCRIPTION
### Motivation
- Prevent a high-priority account-takeover vector by ensuring the signup guard that blocks rebinding an already-linked `patients.auth_uid` does not fail open when the lookup returns an error or multiple rows.

### Description
- Updated `src/hooks/useAuth.ts` to query for existing linked patients using an existence-style query (`.limit(1)`) instead of `.maybeSingle()` and renamed the result to `linkedPatients` for clarity.
- Added an explicit presence check (`linkedPatients && linkedPatients.length > 0`) and preserved the existing fail-closed behavior by returning an error when the lookup returns an error (`linkedPatientError`).
- Left the subsequent conditional update that only updates rows where `.is('auth_uid', null)` intact to preserve race-safe linking.

### Testing
- Ran `npm run typecheck` which completed successfully with no TypeScript errors.  
- Ran `npm run lint` which failed due to pre-existing, repository-wide lint errors unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e2b420d08332832e37215b6739f5)