### PR TITLE
Fail closed on patient lookup errors during signup linking

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -136,12 +136,20 @@ export function useAuth(): UseAuthReturn {
       }
       const normalizedEmail = data.email.toLowerCase().trim();
 
-      const { data: existingPatient } = await supabase
-        .from("patients")
-        .select("id, auth_uid, dob, email, phone")
-        .or(orClauses.join(","))
-        .is("auth_uid", null)
-        .maybeSingle();
+      const { data: existingPatient, error: existingPatientError } =
+        await supabase
+          .from("patients")
+          .select("id, auth_uid, dob, email, phone")
+          .or(orClauses.join(","))
+          .is("auth_uid", null)
+          .maybeSingle();
+
+      if (existingPatientError) {
+        return {
+          message:
+            "We could not automatically verify your clinic profile. Please contact support for identity verification.",
+        };
+      }
 
       if (existingPatient) {
         const normalizedPhone = data.phone ? normalizePhone(data.phone) : null;


### PR DESCRIPTION
### Motivation
- Prevent a fail-open in the `signup` linking flow where query errors from `maybeSingle()` could allow auto-linking and rebind an existing patient record to the new `auth_uid`.

### Description
- In `src/hooks/useAuth.ts` the unlinked-patient lookup now captures the query `error` (`existingPatientError`) from the `maybeSingle()` call and returns a verification-required message instead of continuing to auto-link when that lookup fails, while preserving the existing guard for already-linked patients.

### Testing
- Ran `npm run typecheck` which completed successfully with no TypeScript errors, and ran `npm run lint` which failed due to pre-existing, repository-wide lint issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5e5275df883328b59041690db0277)