### PR TITLE
Follow-up to #61: keep conflict_resolutions.entity_id text-compatible

### DIFF
--- a/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
+++ b/supabase/migrations/20260125094038_add_conflict_resolution_system.sql
@@ -6,7 +6,7 @@
       - `id` (uuid, primary key)
       - `conflict_type` (text) - 'sync_conflict', 'duplicate', 'data_quality'
       - `entity_type` (text) - 'patients', 'vitals', 'consultations', etc.
-      - `entity_id` (uuid) - The primary record involved
+      - `entity_id` (text) - The primary record involved (supports legacy text IDs and UUIDs)
       - `candidate_ids` (uuid[]) - Related records (for duplicates)
       - `status` (text) - 'pending', 'resolved', 'ignored', 'auto_resolved'
       - `priority` (text) - 'low', 'medium', 'high', 'critical'
@@ -59,7 +59,7 @@ CREATE TABLE IF NOT EXISTS conflict_resolutions (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   conflict_type text NOT NULL CHECK (conflict_type IN ('sync_conflict', 'duplicate', 'data_quality')),
   entity_type text NOT NULL,
-  entity_id uuid NOT NULL,
+  entity_id text NOT NULL,
   candidate_ids uuid[] DEFAULT '{}',
   status text NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'resolved', 'ignored', 'auto_resolved', 'needs_approval')),
   priority text NOT NULL DEFAULT 'medium' CHECK (priority IN ('low', 'medium', 'high', 'critical')),


### PR DESCRIPTION
### Motivation
- Prevent runtime failures when legacy non-UUID record IDs are inserted into the conflict system by preserving `conflict_resolutions.entity_id` as `text` so migrations and runtime inserts remain compatible with older migrations that used text-backed IDs.

### Description
- Changed `supabase/migrations/20260125094038_add_conflict_resolution_system.sql` to define `entity_id` as `text` in the `CREATE TABLE` and kept the fallback `ALTER TABLE ... ADD COLUMN IF NOT EXISTS entity_id text`, and updated the migration header comment to document support for legacy text IDs and UUIDs.

### Testing
- Ran pattern searches with `rg` to verify no remaining `entity_id uuid` occurrences and inspected the file with `nl` to confirm the `entity_id` column is `text`, and these checks passed. 
- Ran `git diff --check` to validate there are no formatting issues, and the commit succeeded (`git commit` succeeded) when applying the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5f22b75e0833294398b7c32f388a1)