### PR TITLE
fix(migrations): ensure UUID type safety for patient messages and validate conflict FK types

### DIFF
--- a/supabase/migrations/20251028000000_add_patient_portal.sql
+++ b/supabase/migrations/20251028000000_add_patient_portal.sql
@@ -417,7 +417,7 @@ CREATE POLICY "Patients can send messages"
       SELECT patient_id FROM patient_portal_users WHERE id = auth.uid()
     )
     AND sender_type = 'patient'
-    AND sender_id = auth.uid()
+    AND sender_id = auth.uid()::uuid
   );
 
 CREATE POLICY "Patients can update own messages"
@@ -451,7 +451,7 @@ CREATE POLICY "Staff can send messages to patients"
       SELECT id FROM app_users WHERE role IN ('admin', 'doctor', 'nurse', 'chw')
     )
     AND sender_type = 'staff'
-    AND sender_id = auth.uid()
+    AND sender_id = auth.uid()::uuid
   );
 
 -- ============================================================================


### PR DESCRIPTION
### Motivation
- Prevent migration failures caused by comparing `uuid` columns to `text` values in RLS policies when applying migrations.
- Ensure foreign key column types match primary key types for conflict resolution tables to avoid table creation errors during migrations.

### Description
- Updated `supabase/migrations/20251028000000_add_patient_portal.sql` to cast `auth.uid()` to UUID in patient message insert policies by replacing `sender_id = auth.uid()` with `sender_id = auth.uid()::uuid` for both patient and staff branches.
- Verified that `conflict_audit_logs.conflict_id` and `conflict_change_deltas.conflict_id` are declared as `uuid` and reference `conflict_resolutions(id)` (UUID), so no changes were required in `20260125094038_add_conflict_resolution_system.sql` and `20260125095109_add_conflict_delta_retention_and_archiving.sql`.
- Committed the migration fix and created the follow-up PR to address the issues identified in the review.

### Testing
- Ran static searches to confirm fixes and types with `rg` (searching for `sender_id`, `auth.uid()` casts, and `references conflict_resolutions(id)`) and verified occurrences; the checks succeeded.
- Inspected file snippets with `nl`/`sed` to confirm the `auth.uid()::uuid` replacements and `conflict_id uuid` declarations; the outputs matched expectations.
- Committed the change with `git commit` and validated the repository status; the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5fdca69448332b57a47d86df13ae2)