### PR TITLE
Scope doctor inbox to current staff and mark outbound staff messages unread

### DIFF
--- a/src/features/doctor/PatientMessagesPanel.tsx
+++ b/src/features/doctor/PatientMessagesPanel.tsx
@@ -46,7 +46,10 @@ interface PatientMessagesPanelProps {
   onUnreadChange?: (count: number) => void;
 }
 
-export function PatientMessagesPanel({ onClose, onUnreadChange }: PatientMessagesPanelProps) {
+export function PatientMessagesPanel({
+  onClose,
+  onUnreadChange,
+}: PatientMessagesPanelProps) {
   const { currentUser } = useAuthStore();
   const [threads, setThreads] = useState<PatientThread[]>([]);
   const [selectedPatientId, setSelectedPatientId] = useState<string | null>(
@@ -78,12 +81,18 @@ export function PatientMessagesPanel({ onClose, onUnreadChange }: PatientMessage
       setLoading(false);
       return;
     }
+    if (!currentUser?.id) {
+      setThreads([]);
+      setLoading(false);
+      return;
+    }
 
     setLoadError("");
     try {
       const { data, error: fetchError } = await supabase
         .from("patient_secure_messages")
         .select("*")
+        .or(`staff_id.eq.${currentUser.id},staff_id.is.null`)
         .order("created_at", { ascending: false });
 
       if (fetchError) throw fetchError;
@@ -131,7 +140,7 @@ export function PatientMessagesPanel({ onClose, onUnreadChange }: PatientMessage
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [currentUser?.id]);
 
   useEffect(() => {
     loadMessages();
@@ -216,7 +225,7 @@ export function PatientMessagesPanel({ onClose, onUnreadChange }: PatientMessage
           from_patient: false,
           from_name: currentUser.fullName,
           staff_id: currentUser.id,
-          read: true,
+          read: false,
         });
 
       if (insertError) throw insertError;
@@ -251,7 +260,7 @@ export function PatientMessagesPanel({ onClose, onUnreadChange }: PatientMessage
           from_patient: false,
           from_name: currentUser.fullName,
           staff_id: currentUser.id,
-          read: true,
+          read: false,
         });
 
       if (insertError) throw insertError;


### PR DESCRIPTION
### Motivation
- Fix a high-priority bug where the doctor inbox loaded all `patient_secure_messages` across staff users, exposing other clinicians' threads and inflating unread counts. 
- Fix a high-priority bug where outgoing staff messages were saved with `read: true`, preventing patients from receiving unread indicators/notifications.

### Description
- Restrict the inbox query in `loadMessages` to only return rows where `staff_id` equals the signed-in user or `staff_id IS NULL` by adding an `.or('staff_id.eq.<currentUser.id>,staff_id.is.null')` filter in `src/features/doctor/PatientMessagesPanel.tsx` and guard against loading before `currentUser.id` is available.
- Add `currentUser?.id` to the `loadMessages` `useCallback` dependency list so the query re-scopes when the active user changes.
- Change outbound staff message inserts in both reply and new-message flows within `src/features/doctor/PatientMessagesPanel.tsx` to use `read: false` so patients see unread badges until they open messages.

### Testing
- Ran the staged-file commit hooks which executed `eslint --fix`, `prettier --write`, and `tsc-files --noEmit` successfully for the modified file.
- Ran `npx eslint src/features/doctor/PatientMessagesPanel.tsx` which completed without errors for the changed file.
- Ran `npm run typecheck` which failed due to unrelated duplicate declarations in `src/services/patientService.ts`, and is not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e666b72478833284fa83e06e87b61f)