### PR TITLE
Isolate Palaver Room from Patient Messages on Doctor Dashboard

### DIFF
--- a/src/pages/DoctorDashboard.tsx
+++ b/src/pages/DoctorDashboard.tsx
@@ -5,8 +5,9 @@ import type { Patient, Visit, Vital, QueueItem } from "@/db";
 import { useAuthStore } from "@/stores/auth";
 import { queueManagement } from "@/services/queueManagement";
 import { getFlagColor } from "@/utils/vitals";
-import { getDoctorUnreadCount } from "@/services/patientSecureMessaging";
+import { palaverRoom } from "@/services/palaverRoom";
 import { PatientMessagesPanel } from "@/features/doctor/PatientMessagesPanel";
+import { PalaverRoom } from "@/features/doctor/PalaverRoom";
 import { supabase } from "@/lib/supabase";
 import {
   UserIcon,
@@ -42,10 +43,10 @@ export function DoctorDashboard() {
   const loadUnreadCount = useCallback(async () => {
     if (!userId) return;
     try {
-      const count = await getDoctorUnreadCount(userId);
+      const count = await palaverRoom.getUnreadCount(userId);
       setUnreadMessages(count);
     } catch (err) {
-      console.error("Failed to load unread count:", err);
+      console.error("Failed to load unread Palaver Room count:", err);
     }
   }, [userId]);
 
@@ -240,7 +241,7 @@ export function DoctorDashboard() {
             className="relative flex items-center gap-2 px-4 py-2 bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors shadow-sm"
           >
             <ChatBubbleLeftRightIcon className="h-5 w-5" />
-            <span className="font-medium">Patient Messages</span>
+            <span className="font-medium">Palaver Room</span>
             {unreadMessages > 0 && (
               <span className="absolute -top-2 -right-2 px-2 py-0.5 bg-red-500 text-white text-xs font-bold rounded-full min-w-[20px] text-center">
                 {unreadMessages}
@@ -298,12 +299,12 @@ export function DoctorDashboard() {
             onClick={() => setShowPalaverRoom(false)}
           />
           <div className="fixed right-0 top-0 bottom-0 w-full max-w-md z-50 shadow-2xl">
-            <PatientMessagesPanel
+            <PalaverRoom
               onClose={() => {
                 setShowPalaverRoom(false);
                 loadUnreadCount();
               }}
-              onUnreadChange={setUnreadMessages}
+              isPanel
             />
           </div>
         </>
@@ -542,7 +543,7 @@ export function DoctorDashboard() {
             className="relative btn-secondary flex flex-col items-center justify-center p-4 h-24 bg-emerald-50 border-emerald-200 hover:bg-emerald-100"
           >
             <ChatBubbleLeftRightIcon className="h-6 w-6 mb-2 text-emerald-600" />
-            <span className="text-sm text-emerald-800">Patient Messages</span>
+            <span className="text-sm text-emerald-800">Palaver Room</span>
             {unreadMessages > 0 && (
               <span className="absolute top-2 right-2 px-1.5 py-0.5 bg-red-500 text-white text-xs font-bold rounded-full">
                 {unreadMessages}


### PR DESCRIPTION
### Motivation
- The dashboard was wiring the Palaver entry points to the patient messaging logic and panel, which causes unread counts and UI state to bleed between the two features and display the same badge on both tiles.

### Description
- Replaced the patient unread-count call with the Palaver service by importing `palaverRoom` and calling `palaverRoom.getUnreadCount(userId)` in `loadUnreadCount`.
- Switched the Palaver action buttons and quick-action tile labels from "Patient Messages" to "Palaver Room".
- Render the Palaver UI via the `<PalaverRoom isPanel />` component for the Palaver sliding panel instead of `PatientMessagesPanel`, and removed the incorrect `onUnreadChange` wiring.
- All changes are scoped to `src/pages/DoctorDashboard.tsx` to separate the two modules cleanly.

### Testing
- Ran `npx tsc-files --noEmit src/pages/DoctorDashboard.tsx` which succeeded.
- Ran `npx eslint src/pages/DoctorDashboard.tsx` which succeeded.
- Ran `npm run typecheck` which failed due to pre-existing duplicate declarations in `src/services/patientService.ts` unrelated to this change, so full repo typecheck failure is not caused by this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67072609c8332a78db68294124519)