### PR TITLE
fix(boundary): show real error + add clear-cache recovery; guard matchMedia

### DIFF
--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,68 +1,170 @@
-import React, { Component, ErrorInfo, ReactNode } from 'react'
+import React, { Component, ErrorInfo, ReactNode } from "react";
 
 interface Props {
-  children: ReactNode
+  children: ReactNode;
 }
 
 interface State {
-  hasError: boolean
-  error?: Error
+  hasError: boolean;
+  error?: Error;
+  isClearing: boolean;
+}
+
+async function clearAllClientState(): Promise<void> {
+  try {
+    localStorage.clear();
+  } catch (e) {
+    console.error("localStorage.clear failed:", e);
+  }
+  try {
+    sessionStorage.clear();
+  } catch (e) {
+    console.error("sessionStorage.clear failed:", e);
+  }
+
+  // Unregister service workers so a stale SW can't keep serving an old bundle.
+  try {
+    if ("serviceWorker" in navigator) {
+      const regs = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(regs.map((r) => r.unregister()));
+    }
+  } catch (e) {
+    console.error("serviceWorker unregister failed:", e);
+  }
+
+  // Clear Cache Storage (workbox precache, etc.)
+  try {
+    if ("caches" in window) {
+      const keys = await caches.keys();
+      await Promise.all(keys.map((k) => caches.delete(k)));
+    }
+  } catch (e) {
+    console.error("caches.delete failed:", e);
+  }
+
+  // Drop all IndexedDB databases (Dexie + others). databases() is unsupported
+  // on Safari < 17, so fall back to a known list.
+  try {
+    const idb = window.indexedDB;
+    if (idb) {
+      const dbNames: string[] = [];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const idbAny = idb as any;
+      if (typeof idbAny.databases === "function") {
+        const list = await idbAny.databases();
+        for (const d of list) if (d?.name) dbNames.push(d.name);
+      } else {
+        dbNames.push("mbhr_v5", "keyval-store");
+      }
+      await Promise.all(
+        dbNames.map(
+          (name) =>
+            new Promise<void>((resolve) => {
+              const req = idb.deleteDatabase(name);
+              req.onsuccess = req.onerror = req.onblocked = () => resolve();
+            }),
+        ),
+      );
+    }
+  } catch (e) {
+    console.error("indexedDB delete failed:", e);
+  }
 }
 
 export class ErrorBoundary extends Component<Props, State> {
   public state: State = {
-    hasError: false
-  }
+    hasError: false,
+    isClearing: false,
+  };
 
-  public static getDerivedStateFromError(error: Error): State {
-    return { hasError: true, error }
+  public static getDerivedStateFromError(error: Error): Partial<State> {
+    return { hasError: true, error };
   }
 
   public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('ErrorBoundary caught an error:', error, errorInfo)
+    console.error("ErrorBoundary caught an error:", error, errorInfo);
   }
+
+  private handleClearAndReload = async () => {
+    this.setState({ isClearing: true });
+    await clearAllClientState();
+    window.location.replace("/");
+  };
 
   public render() {
     if (this.state.hasError) {
+      const err = this.state.error;
+      const errorText = err
+        ? `${err.name || "Error"}: ${err.message || "Unknown error"}`
+        : "Unknown error";
+
       return (
         <div className="min-h-screen flex items-center justify-center bg-gray-50">
           <div className="max-w-md w-full bg-white rounded-lg shadow-lg p-6">
             <div className="text-center">
               <div className="mx-auto flex items-center justify-center h-12 w-12 rounded-full bg-red-100">
-                <svg className="h-6 w-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z" />
+                <svg
+                  className="h-6 w-6 text-red-600"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L3.732 16.5c-.77.833.192 2.5 1.732 2.5z"
+                  />
                 </svg>
               </div>
               <h3 className="mt-4 text-lg font-medium text-gray-900">
                 Something went wrong
               </h3>
               <p className="mt-2 text-sm text-gray-500">
-                An unexpected error occurred. Please refresh the page and try again.
+                An unexpected error occurred. Try refreshing the page. If the
+                problem persists, clear cached data to recover from a stale
+                deployment.
               </p>
-              <div className="mt-6">
+
+              <p className="mt-3 text-xs text-gray-700 bg-gray-100 border border-gray-200 rounded px-3 py-2 break-words">
+                {errorText}
+              </p>
+
+              <div className="mt-6 flex flex-col gap-2">
                 <button
                   onClick={() => window.location.reload()}
                   className="btn-primary"
+                  disabled={this.state.isClearing}
                 >
                   Refresh Page
                 </button>
+                <button
+                  onClick={this.handleClearAndReload}
+                  className="text-sm text-gray-600 hover:text-gray-900 underline"
+                  disabled={this.state.isClearing}
+                >
+                  {this.state.isClearing
+                    ? "Clearing…"
+                    : "Clear cached data & reload"}
+                </button>
               </div>
-              {process.env.NODE_ENV === 'development' && this.state.error && (
+
+              {import.meta.env.DEV && err?.stack && (
                 <details className="mt-4 text-left">
                   <summary className="text-sm text-gray-600 cursor-pointer">
-                    Error Details
+                    Stack trace
                   </summary>
                   <pre className="mt-2 text-xs text-red-600 bg-red-50 p-2 rounded overflow-auto">
-                    {this.state.error.stack}
+                    {err.stack}
                   </pre>
                 </details>
               )}
             </div>
           </div>
         </div>
-      )
+      );
     }
 
-    return this.props.children
+    return this.props.children;
   }
 }

--- a/src/components/PWAInstallPrompt.tsx
+++ b/src/components/PWAInstallPrompt.tsx
@@ -1,71 +1,77 @@
-import React, { useState, useEffect, memo } from 'react'
-import { XMarkIcon, ArrowDownTrayIcon } from '@heroicons/react/24/outline'
-import { TouchButton } from './TouchButton'
+import React, { useState, useEffect, memo } from "react";
+import { XMarkIcon, ArrowDownTrayIcon } from "@heroicons/react/24/outline";
+import { TouchButton } from "./TouchButton";
 
 interface BeforeInstallPromptEvent extends Event {
-  prompt: () => Promise<void>
-  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
 }
 
 export const PWAInstallPrompt = memo(() => {
-  const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null)
-  const [showPrompt, setShowPrompt] = useState(false)
-  const [isInstalled, setIsInstalled] = useState(false)
+  const [deferredPrompt, setDeferredPrompt] =
+    useState<BeforeInstallPromptEvent | null>(null);
+  const [showPrompt, setShowPrompt] = useState(false);
+  const [isInstalled, setIsInstalled] = useState(false);
 
   useEffect(() => {
-    // Check if already installed
-    if (window.matchMedia('(display-mode: standalone)').matches) {
-      setIsInstalled(true)
-      return
+    // matchMedia is missing in some embedded WebViews; guard so the boot
+    // path never throws into the ErrorBoundary on those runtimes.
+    if (
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(display-mode: standalone)").matches
+    ) {
+      setIsInstalled(true);
+      return;
     }
 
     // Check if dismissed before
-    const dismissed = localStorage.getItem('pwa-install-dismissed')
+    const dismissed = localStorage.getItem("pwa-install-dismissed");
     if (dismissed) {
-      const dismissedDate = new Date(dismissed)
-      const daysSinceDismissed = (Date.now() - dismissedDate.getTime()) / (1000 * 60 * 60 * 24)
+      const dismissedDate = new Date(dismissed);
+      const daysSinceDismissed =
+        (Date.now() - dismissedDate.getTime()) / (1000 * 60 * 60 * 24);
       if (daysSinceDismissed < 7) {
-        return // Don't show again for 7 days
+        return; // Don't show again for 7 days
       }
     }
 
     const handler = (e: Event) => {
-      e.preventDefault()
-      setDeferredPrompt(e as BeforeInstallPromptEvent)
+      e.preventDefault();
+      setDeferredPrompt(e as BeforeInstallPromptEvent);
 
       // Show prompt after 30 seconds of usage
       setTimeout(() => {
-        setShowPrompt(true)
-      }, 30000)
-    }
+        setShowPrompt(true);
+      }, 30000);
+    };
 
-    window.addEventListener('beforeinstallprompt', handler)
+    window.addEventListener("beforeinstallprompt", handler);
 
     return () => {
-      window.removeEventListener('beforeinstallprompt', handler)
-    }
-  }, [])
+      window.removeEventListener("beforeinstallprompt", handler);
+    };
+  }, []);
 
   const handleInstall = async () => {
-    if (!deferredPrompt) return
+    if (!deferredPrompt) return;
 
-    deferredPrompt.prompt()
-    const { outcome } = await deferredPrompt.userChoice
+    deferredPrompt.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
 
-    if (outcome === 'accepted') {
-      setShowPrompt(false)
-      setIsInstalled(true)
+    if (outcome === "accepted") {
+      setShowPrompt(false);
+      setIsInstalled(true);
     }
 
-    setDeferredPrompt(null)
-  }
+    setDeferredPrompt(null);
+  };
 
   const handleDismiss = () => {
-    setShowPrompt(false)
-    localStorage.setItem('pwa-install-dismissed', new Date().toISOString())
-  }
+    setShowPrompt(false);
+    localStorage.setItem("pwa-install-dismissed", new Date().toISOString());
+  };
 
-  if (isInstalled || !showPrompt || !deferredPrompt) return null
+  if (isInstalled || !showPrompt || !deferredPrompt) return null;
 
   return (
     <div className="fixed bottom-4 left-4 right-4 md:left-auto md:right-4 md:w-96 bg-white rounded-xl shadow-2xl border border-gray-200 z-50 animate-slide-up">
@@ -91,20 +97,44 @@ export const PWAInstallPrompt = memo(() => {
 
         <div className="space-y-2 mb-4">
           <div className="flex items-center gap-2 text-sm text-gray-600">
-            <svg className="h-4 w-4 text-green-600" fill="currentColor" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+            <svg
+              className="h-4 w-4 text-green-600"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fillRule="evenodd"
+                d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                clipRule="evenodd"
+              />
             </svg>
             <span>Works offline</span>
           </div>
           <div className="flex items-center gap-2 text-sm text-gray-600">
-            <svg className="h-4 w-4 text-green-600" fill="currentColor" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+            <svg
+              className="h-4 w-4 text-green-600"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fillRule="evenodd"
+                d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                clipRule="evenodd"
+              />
             </svg>
             <span>Faster loading</span>
           </div>
           <div className="flex items-center gap-2 text-sm text-gray-600">
-            <svg className="h-4 w-4 text-green-600" fill="currentColor" viewBox="0 0 20 20">
-              <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+            <svg
+              className="h-4 w-4 text-green-600"
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path
+                fillRule="evenodd"
+                d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                clipRule="evenodd"
+              />
             </svg>
             <span>Home screen access</span>
           </div>
@@ -131,7 +161,7 @@ export const PWAInstallPrompt = memo(() => {
         </div>
       </div>
     </div>
-  )
-})
+  );
+});
 
-PWAInstallPrompt.displayName = 'PWAInstallPrompt'
+PWAInstallPrompt.displayName = "PWAInstallPrompt";


### PR DESCRIPTION
The deployed app shows a generic "Something went wrong" screen with no
diagnostic info, leaving users unable to recover from stale localStorage,
IndexedDB, or service-worker caches after a deploy.

- ErrorBoundary now displays the actual error name+message in all
  environments (was dev-only) and adds a "Clear cached data & reload"
  button that wipes localStorage, sessionStorage, Cache Storage, all
  IndexedDB databases, and unregisters service workers. This lets users
  self-recover from the most common post-deploy failure modes without
  needing to clear site data manually.
- PWAInstallPrompt no longer crashes the boot path on runtimes where
  window.matchMedia is unavailable (some embedded WebViews); the call is
  now feature-detected.