### PR TITLE
fix: resolve 'Session not found' on Medical History and Messages pages

### DIFF
--- a/src/features/patient-portal/PatientLogin.tsx
+++ b/src/features/patient-portal/PatientLogin.tsx
@@ -7,7 +7,7 @@ import { ArrowRightIcon, ShieldCheckIcon } from "@heroicons/react/24/outline";
 import { useAuth } from "@/hooks/useAuth";
 import { loginPatientPortal } from "@/services/patientPortalAuth";
 import { supabase, isSupabaseEnabled } from "@/lib/supabaseClient";
-import { getPatientProfile } from "@/services/patientService";
+import { getPatientProfile, getPatientProfileByEmail } from "@/services/patientService";
 
 const onlineSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
@@ -62,7 +62,13 @@ export function PatientLogin() {
           data: { user },
         } = await supabase.auth.getUser();
         if (user) {
-          const profileRes = await getPatientProfile(user.id);
+          let profileRes = await getPatientProfile(user.id);
+
+          // Fallback: find patient by email and link auth_uid for this session
+          if (!profileRes.data && user.email) {
+            profileRes = await getPatientProfileByEmail(user.id, user.email);
+          }
+
           if (profileRes.data) {
             localStorage.setItem(
               "patient_portal_user",
@@ -74,10 +80,17 @@ export function PatientLogin() {
                 email: profileRes.data.email,
               }),
             );
+          } else {
+            setError(
+              "Your account was created but we couldn't find your patient profile. " +
+              "Please contact the clinic so staff can link your record."
+            );
+            return;
           }
         }
       } catch {
-        // Non-fatal: Medical History / Messages will show an error if patientId is missing
+        setError("An error occurred loading your profile. Please try again.");
+        return;
       }
     }
     navigate("/patient/dashboard");

--- a/src/features/patient-portal/PatientRegister.tsx
+++ b/src/features/patient-portal/PatientRegister.tsx
@@ -152,9 +152,11 @@ export function PatientRegister() {
               }),
             );
           }
+          // If profile is null here, email confirmation may be required —
+          // the user will be prompted to log in after confirming.
         }
       } catch {
-        // Non-fatal: Medical History / Messages will show an error if patientId is missing
+        // Profile fetch failed; user can still log in after email confirmation
       }
     }
     setStep("success");


### PR DESCRIPTION
When a patient logs in via Supabase Auth and their patients.auth_uid hasn't been set yet (e.g. enrolled by staff before the Supabase Auth migration), getPatientProfile(user.id) returns null. The code silently skipped storing patient_portal_user in localStorage, so every page that read that key showed "Session not found. Please log in again."

Fix: fall back to getPatientProfileByEmail(user.id, user.email) which finds the patient by email and links auth_uid in the background. If both lookups fail, show a clear error rather than navigating to a broken dashboard.