### PR TITLE
feat: archive and delete messages in Patient Messages and Palaver Room

### DIFF
--- a/src/features/doctor/PalaverRoom.tsx
+++ b/src/features/doctor/PalaverRoom.tsx
@@ -21,6 +21,8 @@ import {
   ArrowLeftIcon,
   UserCircleIcon,
   ClockIcon,
+  TrashIcon,
+  ArchiveBoxIcon,
 } from "@heroicons/react/24/outline";
 
 type ViewMode = "inbox" | "sent" | "compose" | "broadcast" | "conversation";
@@ -251,6 +253,100 @@ export function PalaverRoom({ onClose, isPanel = false }: PalaverRoomProps) {
     setViewMode("compose");
   };
 
+  const handleArchiveMessage = async (
+    message: PalaverMessage,
+    e?: React.MouseEvent,
+  ) => {
+    e?.stopPropagation();
+    if (!window.confirm(`Archive "${message.subject}"?`)) return;
+    try {
+      await palaverRoom.archiveMessage(message.id);
+      if (selectedMessage?.id === message.id) {
+        setSelectedMessage(null);
+        setConversationMessages([]);
+        setViewMode("inbox");
+      }
+      await loadData();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to archive message",
+      );
+    }
+  };
+
+  const handleDeleteMessage = async (
+    message: PalaverMessage,
+    e?: React.MouseEvent,
+  ) => {
+    e?.stopPropagation();
+    if (
+      !window.confirm(
+        `Permanently delete "${message.subject}"? This cannot be undone.`,
+      )
+    ) {
+      return;
+    }
+    try {
+      await palaverRoom.deleteMessage(message.id);
+      if (selectedMessage?.id === message.id) {
+        setSelectedMessage(null);
+        setConversationMessages([]);
+        setViewMode("inbox");
+      }
+      await loadData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete message");
+    }
+  };
+
+  const handleArchiveConversation = async () => {
+    if (!selectedMessage || !currentUser) return;
+    const otherUserId =
+      selectedMessage.sender_id === currentUser.id
+        ? selectedMessage.recipient_id
+        : selectedMessage.sender_id;
+    const otherName =
+      selectedMessage.sender_id === currentUser.id
+        ? selectedMessage.recipient_name
+        : selectedMessage.sender_name;
+    if (
+      !window.confirm(
+        `Archive the entire conversation with ${otherName}? It will be hidden from your inbox.`,
+      )
+    ) {
+      return;
+    }
+    try {
+      await palaverRoom.archiveConversation(currentUser.id, otherUserId);
+      setSelectedMessage(null);
+      setConversationMessages([]);
+      setViewMode("inbox");
+      await loadData();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to archive conversation",
+      );
+    }
+  };
+
+  const handleDismissBroadcast = async (broadcast: PalaverBroadcast) => {
+    if (
+      !window.confirm(
+        `Dismiss the announcement "${broadcast.subject}"? It will be removed for everyone.`,
+      )
+    ) {
+      return;
+    }
+    try {
+      await palaverRoom.deleteBroadcast(broadcast.id);
+      await loadData();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to dismiss announcement",
+      );
+    }
+  };
+
   const formatTime = (dateStr: string) => {
     const date = new Date(dateStr);
     const now = new Date();
@@ -418,7 +514,7 @@ export function PalaverRoom({ onClose, isPanel = false }: PalaverRoomProps) {
                           key={broadcast.id}
                           className="p-3 bg-amber-50 border border-amber-200 rounded-lg"
                         >
-                          <div className="flex items-start justify-between">
+                          <div className="flex items-start justify-between gap-2">
                             <div className="flex-1">
                               <div className="flex items-center gap-2 mb-1">
                                 {getPriorityIcon(broadcast.priority)}
@@ -435,6 +531,18 @@ export function PalaverRoom({ onClose, isPanel = false }: PalaverRoomProps) {
                                 {formatTime(broadcast.created_at)}
                               </p>
                             </div>
+                            {broadcast.sender_id === currentUser?.id && (
+                              <button
+                                onClick={() =>
+                                  handleDismissBroadcast(broadcast)
+                                }
+                                className="p-1.5 text-amber-700 hover:text-white hover:bg-amber-700 rounded-md transition-colors flex-shrink-0"
+                                title="Dismiss this announcement for everyone"
+                                aria-label={`Dismiss announcement ${broadcast.subject}`}
+                              >
+                                <XMarkIcon className="h-4 w-4" />
+                              </button>
+                            )}
                           </div>
                         </div>
                       ))}
@@ -458,45 +566,67 @@ export function PalaverRoom({ onClose, isPanel = false }: PalaverRoomProps) {
                 ) : (
                   <div className="space-y-2">
                     {messages.map((message) => (
-                      <button
+                      <div
                         key={message.id}
-                        onClick={() => handleOpenMessage(message)}
-                        className={`w-full text-left p-3 rounded-lg border transition-colors ${
+                        className={`group relative rounded-lg border transition-colors ${
                           message.is_read
                             ? "bg-white border-gray-200 hover:bg-gray-50"
                             : "bg-emerald-50 border-emerald-200 hover:bg-emerald-100"
                         }`}
                       >
-                        <div className="flex items-start gap-3">
-                          <UserCircleIcon className="h-10 w-10 text-gray-400 flex-shrink-0" />
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center justify-between mb-1">
-                              <span
-                                className={`font-medium ${!message.is_read ? "text-gray-900" : "text-gray-700"}`}
-                              >
-                                {message.sender_name}
-                              </span>
-                              <div className="flex items-center gap-2">
-                                {getPriorityIcon(message.priority)}
-                                <span className="text-xs text-gray-500">
-                                  {formatTime(message.created_at)}
+                        <button
+                          onClick={() => handleOpenMessage(message)}
+                          className="w-full text-left p-3"
+                        >
+                          <div className="flex items-start gap-3">
+                            <UserCircleIcon className="h-10 w-10 text-gray-400 flex-shrink-0" />
+                            <div className="flex-1 min-w-0 pr-16">
+                              <div className="flex items-center justify-between mb-1">
+                                <span
+                                  className={`font-medium ${!message.is_read ? "text-gray-900" : "text-gray-700"}`}
+                                >
+                                  {message.sender_name}
                                 </span>
+                                <div className="flex items-center gap-2">
+                                  {getPriorityIcon(message.priority)}
+                                  <span className="text-xs text-gray-500">
+                                    {formatTime(message.created_at)}
+                                  </span>
+                                </div>
                               </div>
+                              <p
+                                className={`text-sm ${!message.is_read ? "font-medium text-gray-900" : "text-gray-700"}`}
+                              >
+                                {message.subject}
+                              </p>
+                              <p className="text-sm text-gray-500 truncate">
+                                {message.body}
+                              </p>
                             </div>
-                            <p
-                              className={`text-sm ${!message.is_read ? "font-medium text-gray-900" : "text-gray-700"}`}
-                            >
-                              {message.subject}
-                            </p>
-                            <p className="text-sm text-gray-500 truncate">
-                              {message.body}
-                            </p>
+                            {!message.is_read && (
+                              <div className="w-2 h-2 rounded-full bg-emerald-500 flex-shrink-0 mt-2"></div>
+                            )}
                           </div>
-                          {!message.is_read && (
-                            <div className="w-2 h-2 rounded-full bg-emerald-500 flex-shrink-0 mt-2"></div>
-                          )}
+                        </button>
+                        <div className="absolute right-2 bottom-2 flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+                          <button
+                            onClick={(e) => handleArchiveMessage(message, e)}
+                            className="p-1.5 text-gray-500 hover:text-gray-900 hover:bg-white rounded-md border border-transparent hover:border-gray-200"
+                            title="Archive message"
+                            aria-label={`Archive message ${message.subject}`}
+                          >
+                            <ArchiveBoxIcon className="h-4 w-4" />
+                          </button>
+                          <button
+                            onClick={(e) => handleDeleteMessage(message, e)}
+                            className="p-1.5 text-red-500 hover:text-white hover:bg-red-600 rounded-md border border-transparent hover:border-red-600"
+                            title="Delete message"
+                            aria-label={`Delete message ${message.subject}`}
+                          >
+                            <TrashIcon className="h-4 w-4" />
+                          </button>
                         </div>
-                      </button>
+                      </div>
                     ))}
                   </div>
                 )}
@@ -731,16 +861,34 @@ export function PalaverRoom({ onClose, isPanel = false }: PalaverRoomProps) {
             {/* Conversation View */}
             {viewMode === "conversation" && selectedMessage && (
               <div className="space-y-4">
-                <div className="flex items-center justify-between">
-                  <h3 className="text-lg font-semibold text-gray-900">
+                <div className="flex items-center justify-between gap-2">
+                  <h3 className="text-lg font-semibold text-gray-900 truncate">
                     {selectedMessage.subject}
                   </h3>
-                  <button
-                    onClick={handleReply}
-                    className="px-3 py-1.5 bg-emerald-600 text-white text-sm rounded-lg hover:bg-emerald-700 transition-colors"
-                  >
-                    Reply
-                  </button>
+                  <div className="flex items-center gap-2 flex-shrink-0">
+                    <button
+                      onClick={handleReply}
+                      className="px-3 py-1.5 bg-emerald-600 text-white text-sm rounded-lg hover:bg-emerald-700 transition-colors"
+                    >
+                      Reply
+                    </button>
+                    <button
+                      onClick={handleArchiveConversation}
+                      className="flex items-center gap-1 px-2.5 py-1.5 text-sm text-gray-600 hover:text-gray-900 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+                      title="Archive entire conversation"
+                    >
+                      <ArchiveBoxIcon className="h-4 w-4" />
+                      Archive
+                    </button>
+                    <button
+                      onClick={(e) => handleDeleteMessage(selectedMessage, e)}
+                      className="flex items-center gap-1 px-2.5 py-1.5 text-sm text-red-600 hover:text-white border border-red-300 rounded-lg hover:bg-red-600 transition-colors"
+                      title="Delete this message"
+                    >
+                      <TrashIcon className="h-4 w-4" />
+                      Delete
+                    </button>
+                  </div>
                 </div>
 
                 <div className="space-y-3">

--- a/src/features/doctor/PatientMessagesPanel.tsx
+++ b/src/features/doctor/PatientMessagesPanel.tsx
@@ -11,7 +11,13 @@ import {
   ExclamationTriangleIcon,
   PencilSquareIcon,
   MagnifyingGlassIcon,
+  TrashIcon,
+  ArchiveBoxIcon,
 } from "@heroicons/react/24/outline";
+import {
+  archivePatientThread,
+  deletePatientThread,
+} from "@/services/patientSecureMessaging";
 
 interface PatientMessage {
   id: string;
@@ -87,6 +93,7 @@ export function PatientMessagesPanel({
       const { data, error: fetchError } = await supabase
         .from("patient_secure_messages")
         .select("*")
+        .eq("is_archived", false)
         .order("created_at", { ascending: false });
 
       if (fetchError) throw fetchError;
@@ -282,6 +289,47 @@ export function PatientMessagesPanel({
     setComposeSubject("");
     setComposeBody("");
     setError("");
+  };
+
+  const handleArchiveThread = async (
+    patientId: string,
+    patientName: string,
+  ) => {
+    if (
+      !window.confirm(
+        `Archive the conversation with ${patientName}? It will be hidden from the inbox but kept in the patient's record.`,
+      )
+    ) {
+      return;
+    }
+    try {
+      await archivePatientThread(patientId);
+      if (selectedPatientId === patientId) goToInbox();
+      await loadMessages();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to archive conversation",
+      );
+    }
+  };
+
+  const handleDeleteThread = async (patientId: string, patientName: string) => {
+    if (
+      !window.confirm(
+        `Permanently delete the entire conversation with ${patientName}? This cannot be undone.`,
+      )
+    ) {
+      return;
+    }
+    try {
+      await deletePatientThread(patientId);
+      if (selectedPatientId === patientId) goToInbox();
+      await loadMessages();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to delete conversation",
+      );
+    }
   };
 
   const selectedThread =
@@ -480,6 +528,34 @@ export function PatientMessagesPanel({
         ) : viewMode === "conversation" && selectedThread ? (
           /* Conversation view */
           <div className="flex flex-col flex-1">
+            <div className="flex items-center justify-end gap-2 mb-3">
+              <button
+                onClick={() =>
+                  handleArchiveThread(
+                    selectedThread.patient_id,
+                    selectedThread.patient_name,
+                  )
+                }
+                className="flex items-center gap-1 px-2.5 py-1 text-xs text-gray-600 hover:text-gray-900 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+                title="Archive conversation"
+              >
+                <ArchiveBoxIcon className="h-4 w-4" />
+                Archive
+              </button>
+              <button
+                onClick={() =>
+                  handleDeleteThread(
+                    selectedThread.patient_id,
+                    selectedThread.patient_name,
+                  )
+                }
+                className="flex items-center gap-1 px-2.5 py-1 text-xs text-red-600 hover:text-white border border-red-300 rounded-lg hover:bg-red-600 transition-colors"
+                title="Permanently delete conversation"
+              >
+                <TrashIcon className="h-4 w-4" />
+                Delete
+              </button>
+            </div>
             <div className="flex-1 space-y-3 mb-4">
               {selectedThread.messages.map((msg) => (
                 <div
@@ -552,42 +628,76 @@ export function PatientMessagesPanel({
           /* Thread list */
           <div className="space-y-2">
             {threads.map((thread) => (
-              <button
+              <div
                 key={thread.patient_id}
-                onClick={() => openThread(thread)}
-                className={`w-full text-left p-3 rounded-lg border transition-colors ${
+                className={`group relative rounded-lg border transition-colors ${
                   thread.unread_count > 0
                     ? "bg-blue-50 border-blue-200 hover:bg-blue-100"
                     : "bg-white border-gray-200 hover:bg-gray-50"
                 }`}
               >
-                <div className="flex items-start gap-3">
-                  <UserCircleIcon className="h-10 w-10 text-gray-400 flex-shrink-0" />
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center justify-between mb-0.5">
-                      <span
-                        className={`font-medium text-sm ${thread.unread_count > 0 ? "text-gray-900" : "text-gray-700"}`}
-                      >
-                        {thread.patient_name}
-                      </span>
-                      <span className="text-xs text-gray-500 ml-2 flex-shrink-0">
-                        {formatNigerianDate(thread.latest_message.created_at)}
-                      </span>
+                <button
+                  onClick={() => openThread(thread)}
+                  className="w-full text-left p-3"
+                >
+                  <div className="flex items-start gap-3">
+                    <UserCircleIcon className="h-10 w-10 text-gray-400 flex-shrink-0" />
+                    <div className="flex-1 min-w-0 pr-16">
+                      <div className="flex items-center justify-between mb-0.5">
+                        <span
+                          className={`font-medium text-sm ${thread.unread_count > 0 ? "text-gray-900" : "text-gray-700"}`}
+                        >
+                          {thread.patient_name}
+                        </span>
+                        <span className="text-xs text-gray-500 ml-2 flex-shrink-0">
+                          {formatNigerianDate(thread.latest_message.created_at)}
+                        </span>
+                      </div>
+                      <p className="text-sm text-gray-600 truncate">
+                        {thread.latest_message.subject}
+                      </p>
+                      <p className="text-xs text-gray-500 truncate">
+                        {thread.latest_message.body}
+                      </p>
                     </div>
-                    <p className="text-sm text-gray-600 truncate">
-                      {thread.latest_message.subject}
-                    </p>
-                    <p className="text-xs text-gray-500 truncate">
-                      {thread.latest_message.body}
-                    </p>
+                    {thread.unread_count > 0 && (
+                      <span className="px-1.5 py-0.5 bg-blue-600 text-white text-xs font-bold rounded-full flex-shrink-0 mt-1">
+                        {thread.unread_count}
+                      </span>
+                    )}
                   </div>
-                  {thread.unread_count > 0 && (
-                    <span className="px-1.5 py-0.5 bg-blue-600 text-white text-xs font-bold rounded-full flex-shrink-0 mt-1">
-                      {thread.unread_count}
-                    </span>
-                  )}
+                </button>
+                <div className="absolute right-2 bottom-2 flex items-center gap-1 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleArchiveThread(
+                        thread.patient_id,
+                        thread.patient_name,
+                      );
+                    }}
+                    className="p-1.5 text-gray-500 hover:text-gray-900 hover:bg-white rounded-md border border-transparent hover:border-gray-200"
+                    title="Archive conversation"
+                    aria-label={`Archive conversation with ${thread.patient_name}`}
+                  >
+                    <ArchiveBoxIcon className="h-4 w-4" />
+                  </button>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDeleteThread(
+                        thread.patient_id,
+                        thread.patient_name,
+                      );
+                    }}
+                    className="p-1.5 text-red-500 hover:text-white hover:bg-red-600 rounded-md border border-transparent hover:border-red-600"
+                    title="Delete conversation"
+                    aria-label={`Delete conversation with ${thread.patient_name}`}
+                  >
+                    <TrashIcon className="h-4 w-4" />
+                  </button>
                 </div>
-              </button>
+              </div>
             ))}
           </div>
         )}

--- a/src/services/palaverRoom.ts
+++ b/src/services/palaverRoom.ts
@@ -283,6 +283,56 @@ class PalaverRoomService {
 
     if (error) {
       logger.error("Failed to archive message:", error);
+      throw new Error(`Failed to archive message: ${error.message}`);
+    }
+  }
+
+  async archiveConversation(
+    userId: string,
+    otherUserId: string,
+  ): Promise<void> {
+    if (!supabase) return;
+
+    const conversation = await this.getConversation(userId, otherUserId);
+    const ids = conversation.map((m) => m.id);
+    if (ids.length === 0) return;
+
+    const { error } = await supabase
+      .from("palaver_messages")
+      .update({ is_archived: true })
+      .in("id", ids);
+
+    if (error) {
+      logger.error("Failed to archive conversation:", error);
+      throw new Error(`Failed to archive conversation: ${error.message}`);
+    }
+  }
+
+  async deleteMessage(messageId: string): Promise<void> {
+    if (!supabase) return;
+
+    const { error } = await supabase
+      .from("palaver_messages")
+      .delete()
+      .eq("id", messageId);
+
+    if (error) {
+      logger.error("Failed to delete message:", error);
+      throw new Error(`Failed to delete message: ${error.message}`);
+    }
+  }
+
+  async deleteBroadcast(broadcastId: string): Promise<void> {
+    if (!supabase) return;
+
+    const { error } = await supabase
+      .from("palaver_broadcasts")
+      .update({ is_active: false })
+      .eq("id", broadcastId);
+
+    if (error) {
+      logger.error("Failed to dismiss broadcast:", error);
+      throw new Error(`Failed to dismiss broadcast: ${error.message}`);
     }
   }
 

--- a/src/services/patientSecureMessaging.ts
+++ b/src/services/patientSecureMessaging.ts
@@ -159,3 +159,51 @@ export async function markMessageRead(messageId: string) {
 
   if (error) throw error;
 }
+
+export async function archivePatientThread(patientId: string) {
+  if (!supabase) {
+    throw new Error("Secure messaging is unavailable while offline.");
+  }
+  const { error } = await supabase
+    .from("patient_secure_messages")
+    .update({ is_archived: true })
+    .eq("patient_id", patientId);
+
+  if (error) throw error;
+}
+
+export async function deletePatientThread(patientId: string) {
+  if (!supabase) {
+    throw new Error("Secure messaging is unavailable while offline.");
+  }
+  const { error } = await supabase
+    .from("patient_secure_messages")
+    .delete()
+    .eq("patient_id", patientId);
+
+  if (error) throw error;
+}
+
+export async function archiveSecureMessage(messageId: string) {
+  if (!supabase) {
+    throw new Error("Secure messaging is unavailable while offline.");
+  }
+  const { error } = await supabase
+    .from("patient_secure_messages")
+    .update({ is_archived: true })
+    .eq("id", messageId);
+
+  if (error) throw error;
+}
+
+export async function deleteSecureMessage(messageId: string) {
+  if (!supabase) {
+    throw new Error("Secure messaging is unavailable while offline.");
+  }
+  const { error } = await supabase
+    .from("patient_secure_messages")
+    .delete()
+    .eq("id", messageId);
+
+  if (error) throw error;
+}

--- a/supabase/migrations/20260503000000_add_message_archiving_and_delete.sql
+++ b/supabase/migrations/20260503000000_add_message_archiving_and_delete.sql
@@ -1,0 +1,50 @@
+/*
+  # Message archiving and deletion support
+
+  Lets clinical staff resolve / remove messages in:
+    - Patient Messages (patient_secure_messages)
+    - Palaver Room    (palaver_messages, palaver_broadcasts)
+
+  ## Changes
+  1. Add `is_archived` column (default false) to `patient_secure_messages`
+     and an index to keep filtered inbox queries fast.
+  2. Add permissive RLS policies on `patient_secure_messages` so the app
+     (which uses the anon key plus app-layer auth) can update / delete
+     messages — mirroring the model already used for palaver_messages
+     in 20251214163828_fix_palaver_room_rls_policies.sql.
+
+  Palaver tables already have full CRUD policies and an `is_archived`
+  column, so no schema changes are needed there.
+*/
+
+-- 1. patient_secure_messages: archive column ------------------------------
+ALTER TABLE patient_secure_messages
+  ADD COLUMN IF NOT EXISTS is_archived BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_secure_messages_active
+  ON patient_secure_messages(patient_id, created_at DESC)
+  WHERE is_archived = false;
+
+-- 2. patient_secure_messages: permissive update / delete policies ---------
+-- The app authenticates locally (IndexedDB) and connects to Supabase via
+-- the anon key, so the existing JWT-role-based policies block updates and
+-- deletes. Add open policies that match the existing palaver_messages
+-- model; access control is enforced in the application layer.
+
+DROP POLICY IF EXISTS "Allow update on patient_secure_messages"
+  ON patient_secure_messages;
+CREATE POLICY "Allow update on patient_secure_messages"
+  ON patient_secure_messages FOR UPDATE
+  TO anon, authenticated
+  USING (true)
+  WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Allow delete on patient_secure_messages"
+  ON patient_secure_messages;
+CREATE POLICY "Allow delete on patient_secure_messages"
+  ON patient_secure_messages FOR DELETE
+  TO anon, authenticated
+  USING (true);
+
+COMMENT ON COLUMN patient_secure_messages.is_archived IS
+  'Soft-delete flag set by staff to dismiss/resolve a thread from the inbox.';


### PR DESCRIPTION
Staff had no way to clear out the Patient Messages inbox or Palaver Room
once a conversation was resolved. Add per-row Archive (soft hide) and
Delete (permanent) controls plus matching actions in the conversation
header. Sender of a Palaver broadcast can now dismiss it for everyone.

- Add `is_archived` column + permissive update/delete RLS policies on
  `patient_secure_messages` (mirrors existing palaver_messages model).
- New service helpers: archive/delete patient threads and individual
  secure messages; deleteMessage / archiveConversation / deleteBroadcast
  on palaverRoom.
- Inbox queries filter archived rows; staff archive does not affect
  patient-side history.