### PR TITLE
Add error handling for Supabase realtime subscriptions

### DIFF
--- a/src/features/doctor/PatientMessagesPanel.tsx
+++ b/src/features/doctor/PatientMessagesPanel.tsx
@@ -148,17 +148,25 @@ export function PatientMessagesPanel({
 
     if (!supabase) return;
 
-    const channel = supabase
-      .channel("staff_patient_messages")
-      .on(
-        "postgres_changes",
-        { event: "*", schema: "public", table: "patient_secure_messages" },
-        () => loadMessages(),
-      )
-      .subscribe();
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+    try {
+      channel = supabase
+        .channel("staff_patient_messages")
+        .on(
+          "postgres_changes",
+          { event: "*", schema: "public", table: "patient_secure_messages" },
+          () => loadMessages(),
+        )
+        .subscribe();
+    } catch (err) {
+      console.warn(
+        "[PatientMessagesPanel] Realtime unavailable; live message updates disabled:",
+        err,
+      );
+    }
 
     return () => {
-      supabase!.removeChannel(channel);
+      if (channel) supabase!.removeChannel(channel);
     };
   }, [loadMessages]);
 

--- a/src/features/patient-portal/SecureMessaging.tsx
+++ b/src/features/patient-portal/SecureMessaging.tsx
@@ -47,23 +47,31 @@ export function SecureMessaging() {
 
     if (!supabase) return;
 
-    const channel = supabase
-      .channel("secure_messages")
-      .on(
-        "postgres_changes",
-        {
-          event: "*",
-          schema: "public",
-          table: "patient_secure_messages",
-        },
-        () => {
-          loadMessages();
-        },
-      )
-      .subscribe();
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+    try {
+      channel = supabase
+        .channel("secure_messages")
+        .on(
+          "postgres_changes",
+          {
+            event: "*",
+            schema: "public",
+            table: "patient_secure_messages",
+          },
+          () => {
+            loadMessages();
+          },
+        )
+        .subscribe();
+    } catch (err) {
+      console.warn(
+        "[SecureMessaging] Realtime unavailable; live message updates disabled:",
+        err,
+      );
+    }
 
     return () => {
-      supabase!.removeChannel(channel);
+      if (channel) supabase!.removeChannel(channel);
     };
   }, []);
 

--- a/src/services/queueManagement.ts
+++ b/src/services/queueManagement.ts
@@ -430,27 +430,34 @@ export class QueueManagement {
   async setupRealtimeSync(stage: QueueStage): Promise<void> {
     if (!supabase) return;
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const _channel = supabase
-      .channel(`queue:${stage}`)
-      .on(
-        "postgres_changes",
-        {
-          event: "*",
-          schema: "public",
-          table: "queue",
-          filter: `stage=eq.${stage}`,
-        },
-        async (payload) => {
-          logger.log("Queue update received from Supabase", payload);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _channel = supabase
+        .channel(`queue:${stage}`)
+        .on(
+          "postgres_changes",
+          {
+            event: "*",
+            schema: "public",
+            table: "queue",
+            filter: `stage=eq.${stage}`,
+          },
+          async (payload) => {
+            logger.log("Queue update received from Supabase", payload);
 
-          // Reload queue from local DB (which will have synced)
-          this.notifySubscribers(stage);
-        },
-      )
-      .subscribe();
+            // Reload queue from local DB (which will have synced)
+            this.notifySubscribers(stage);
+          },
+        )
+        .subscribe();
 
-    logger.log(`Realtime sync enabled for ${stage} queue`);
+      logger.log(`Realtime sync enabled for ${stage} queue`);
+    } catch (err) {
+      logger.warn(
+        `[queue] Realtime unavailable for ${stage}; live updates disabled:`,
+        err,
+      );
+    }
   }
 
   async exportQueueData(stage?: QueueStage): Promise<string> {

--- a/src/services/realtimeSync.ts
+++ b/src/services/realtimeSync.ts
@@ -88,20 +88,27 @@ class RealtimeSyncService {
           }
         : { event: config.event || "*", schema: "public", table: config.table };
 
-      const channel = client
-        .channel(channelKey)
-        .on("postgres_changes", pgConfig, handlePayload)
-        .subscribe((status) => {
-          if (status === "SUBSCRIBED") {
-            logger.log(`Subscribed to ${channelKey}`);
-            this.channelReconnectAttempts.delete(channelKey);
-          } else if (status === "CHANNEL_ERROR") {
-            logger.error(`Channel error for ${channelKey}`);
-            this.handleReconnect(channelKey, config);
-          }
-        });
+      try {
+        const channel = client
+          .channel(channelKey)
+          .on("postgres_changes", pgConfig, handlePayload)
+          .subscribe((status) => {
+            if (status === "SUBSCRIBED") {
+              logger.log(`Subscribed to ${channelKey}`);
+              this.channelReconnectAttempts.delete(channelKey);
+            } else if (status === "CHANNEL_ERROR") {
+              logger.error(`Channel error for ${channelKey}`);
+              this.handleReconnect(channelKey, config);
+            }
+          });
 
-      this.channels.set(channelKey, channel);
+        this.channels.set(channelKey, channel);
+      } catch (err) {
+        logger.warn(
+          `Realtime unavailable for ${channelKey}; live updates disabled (likely Safari Private Browsing or blocked WebSocket):`,
+          err,
+        );
+      }
     }
 
     return () => {

--- a/src/services/supabaseSync.ts
+++ b/src/services/supabaseSync.ts
@@ -137,7 +137,6 @@ class SupabaseSync {
       });
 
       return { success: true };
-       
     } catch (error: unknown) {
       this.updateStatus({
         status: "error",
@@ -292,7 +291,6 @@ class SupabaseSync {
       });
 
       return { success: true };
-       
     } catch (error: unknown) {
       this.updateStatus({
         status: "error",
@@ -323,18 +321,26 @@ class SupabaseSync {
   async setupRealtimeSync(table: string, callback: () => void) {
     if (!this.client) return null;
 
-    return this.client
-      .channel(`public:${table}`)
-      .on(
-        "postgres_changes",
-        {
-          event: "*",
-          schema: "public",
-          table,
-        },
-        callback,
-      )
-      .subscribe();
+    try {
+      return this.client
+        .channel(`public:${table}`)
+        .on(
+          "postgres_changes",
+          {
+            event: "*",
+            schema: "public",
+            table,
+          },
+          callback,
+        )
+        .subscribe();
+    } catch (err) {
+      console.warn(
+        `[supabaseSync] Realtime unavailable for public:${table}; live sync disabled:`,
+        err,
+      );
+      return null;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
This PR adds comprehensive error handling for Supabase realtime channel subscriptions across the application. Previously, realtime subscription failures could cause unhandled exceptions. Now, failures are gracefully caught and logged, allowing the application to continue functioning with degraded realtime capabilities.

## Key Changes
- **queueManagement.ts**: Wrapped `setupRealtimeSync()` in try-catch to handle subscription failures and log warnings
- **SecureMessaging.tsx**: Added try-catch around realtime channel subscription with null-safe cleanup in the return function
- **realtimeSync.ts**: Wrapped channel subscription in try-catch with detailed error logging mentioning Safari Private Browsing and WebSocket blocking as common causes
- **supabaseSync.ts**: Added try-catch to `setupRealtimeSync()` method with graceful null return on failure; also cleaned up trailing whitespace
- **PatientMessagesPanel.tsx**: Added try-catch around realtime subscription with null-safe channel cleanup

## Implementation Details
- All error handlers log warnings with context about which feature/table is affected
- Cleanup functions now safely check if channels exist before attempting removal
- Errors are caught but don't prevent the application from functioning—users simply won't receive live updates
- Error messages include helpful context (e.g., Safari Private Browsing limitations in realtimeSync.ts)
- Consistent error handling pattern applied across all realtime subscription points

https://claude.ai/code/session_016A7MSYdDH3sbjoQA1aAfBK