### PR TITLE
Handle WebSocket unavailability in Safari Private Browsing

### DIFF
--- a/src/features/doctor/PatientMessagesPanel.tsx
+++ b/src/features/doctor/PatientMessagesPanel.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { supabase } from "@/lib/supabase";
+import { isRealtimeAvailable } from "@/lib/realtimeAvailable";
 import { useAuthStore } from "@/stores/auth";
 import { formatNigerianDate } from "@/utils/dateFormat";
 import {
@@ -147,6 +148,7 @@ export function PatientMessagesPanel({
     loadMessages();
 
     if (!supabase) return;
+    if (!isRealtimeAvailable()) return;
 
     let channel: ReturnType<typeof supabase.channel> | null = null;
     try {

--- a/src/features/patient-portal/SecureMessaging.tsx
+++ b/src/features/patient-portal/SecureMessaging.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/lib/supabase";
+import { isRealtimeAvailable } from "@/lib/realtimeAvailable";
 import * as logger from "@/lib/logger";
 import { formatNigerianDate } from "@/utils/dateFormat";
 import {
@@ -46,6 +47,7 @@ export function SecureMessaging() {
     loadMessages();
 
     if (!supabase) return;
+    if (!isRealtimeAvailable()) return;
 
     let channel: ReturnType<typeof supabase.channel> | null = null;
     try {

--- a/src/lib/realtimeAvailable.ts
+++ b/src/lib/realtimeAvailable.ts
@@ -1,0 +1,34 @@
+/**
+ * Synchronously probe whether `new WebSocket(...)` is usable in this context.
+ *
+ * Safari Private Browsing throws `SecurityError: The operation is insecure.`
+ * from the WebSocket constructor itself. Some corporate proxies and locked-down
+ * WebViews raise similar synchronous errors. When that happens, every Supabase
+ * realtime channel.subscribe() call eventually surfaces an unhandled error
+ * (sometimes async, via the Phoenix socket timer) and brings down the React
+ * tree. Probing once at module load lets every call site short-circuit cleanly.
+ */
+let cached: boolean | null = null;
+
+export function isRealtimeAvailable(): boolean {
+  if (cached !== null) return cached;
+  if (typeof WebSocket === "undefined") {
+    cached = false;
+    return false;
+  }
+  try {
+    // `.invalid` TLD is reserved (RFC2606) and never resolves. Safari Private
+    // Browsing throws synchronously here; healthy environments construct fine
+    // and we close immediately before the DNS lookup completes.
+    const ws = new WebSocket("wss://mbhr-realtime-probe.invalid/");
+    try {
+      ws.close();
+    } catch {
+      /* noop */
+    }
+    cached = true;
+  } catch {
+    cached = false;
+  }
+  return cached;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -39,13 +39,44 @@ if (import.meta.env.VITE_SENTRY_DSN) {
   });
 }
 
-// Global error visibility
-window.addEventListener("error", (ev) =>
-  console.error("[global error]", ev.message, ev.error),
-);
-window.addEventListener("unhandledrejection", (ev) =>
-  console.error("[unhandledrejection]", ev.reason),
-);
+// Safari Private Browsing (and some locked-down WebViews) throw
+// "SecurityError: The operation is insecure." from the WebSocket constructor.
+// Supabase realtime sometimes surfaces this as an async unhandled error after
+// our sync try/catch returns. Swallow it here so the React tree doesn't crash.
+function isWebSocketSecurityError(reason: unknown): boolean {
+  if (!reason) return false;
+  const msg =
+    typeof reason === "string"
+      ? reason
+      : reason instanceof Error
+        ? `${reason.name}: ${reason.message}`
+        : String((reason as { message?: unknown })?.message ?? "");
+  return (
+    msg.includes("WebSocket not available") ||
+    msg.includes("The operation is insecure") ||
+    (msg.includes("SecurityError") && msg.toLowerCase().includes("websocket"))
+  );
+}
+
+window.addEventListener("error", (ev) => {
+  if (
+    isWebSocketSecurityError(ev.error) ||
+    isWebSocketSecurityError(ev.message)
+  ) {
+    console.warn("[realtime] WebSocket unavailable, live updates disabled");
+    ev.preventDefault();
+    return;
+  }
+  console.error("[global error]", ev.message, ev.error);
+});
+window.addEventListener("unhandledrejection", (ev) => {
+  if (isWebSocketSecurityError(ev.reason)) {
+    console.warn("[realtime] WebSocket unavailable, live updates disabled");
+    ev.preventDefault();
+    return;
+  }
+  console.error("[unhandledrejection]", ev.reason);
+});
 
 function renderFatal(msg: string) {
   const el = document.getElementById("root");

--- a/src/services/queueManagement.ts
+++ b/src/services/queueManagement.ts
@@ -1,6 +1,7 @@
 import { db, QueueItem, Patient, generateId, epochDay } from "@/db";
 import { supabase } from "@/lib/supabase";
 import logger from "@/lib/logger";
+import { isRealtimeAvailable } from "@/lib/realtimeAvailable";
 
 export type QueueStage = "registration" | "vitals" | "consult" | "pharmacy";
 export type QueueStatus = "waiting" | "in_progress" | "done";
@@ -429,6 +430,7 @@ export class QueueManagement {
 
   async setupRealtimeSync(stage: QueueStage): Promise<void> {
     if (!supabase) return;
+    if (!isRealtimeAvailable()) return;
 
     try {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/services/realtimeSync.ts
+++ b/src/services/realtimeSync.ts
@@ -1,6 +1,7 @@
 import { supabase } from "@/lib/supabase";
 import { RealtimeChannel } from "@supabase/supabase-js";
 import * as logger from "@/lib/logger";
+import { isRealtimeAvailable } from "@/lib/realtimeAvailable";
 
 type RealtimeEvent = "INSERT" | "UPDATE" | "DELETE" | "*";
 
@@ -48,6 +49,13 @@ class RealtimeSyncService {
   subscribe(config: SubscriptionConfig): () => void {
     if (!supabase) {
       logger.warn("Supabase not initialized, cannot subscribe");
+      return () => {};
+    }
+
+    if (!isRealtimeAvailable()) {
+      // WebSocket constructor throws (Safari Private Browsing, locked-down
+      // WebView, etc.). Skip realtime entirely so the supabase client never
+      // attempts a connection that would crash the React tree.
       return () => {};
     }
 

--- a/src/services/supabaseSync.ts
+++ b/src/services/supabaseSync.ts
@@ -3,6 +3,7 @@ import { createClient, SupabaseClient } from "@supabase/supabase-js";
 import { db } from "@/db";
 import { queryCache } from "@/utils/queryCache";
 import { getErrorMessage } from "@/utils/errors";
+import { isRealtimeAvailable } from "@/lib/realtimeAvailable";
 
 interface SyncStatus {
   lastSync: Date | null;
@@ -320,6 +321,7 @@ class SupabaseSync {
 
   async setupRealtimeSync(table: string, callback: () => void) {
     if (!this.client) return null;
+    if (!isRealtimeAvailable()) return null;
 
     try {
       return this.client


### PR DESCRIPTION
## Summary
This PR adds graceful handling for environments where WebSocket is unavailable or blocked (Safari Private Browsing, locked-down WebViews, corporate proxies). Previously, these environments would cause unhandled errors that crashed the React tree. Now the app detects WebSocket unavailability upfront and disables realtime features cleanly.

## Key Changes
- **New module `src/lib/realtimeAvailable.ts`**: Adds `isRealtimeAvailable()` function that synchronously probes WebSocket availability at module load time by attempting to construct a WebSocket to a reserved invalid domain. Results are cached to avoid repeated probes.

- **Enhanced global error handlers in `src/main.tsx`**: Added `isWebSocketSecurityError()` helper to detect WebSocket-related security errors. Both `error` and `unhandledrejection` event listeners now:
  - Check if the error is a WebSocket security error
  - Log a warning and prevent default if detected (preventing React tree crash)
  - Otherwise log as normal errors

- **Realtime guard checks**: Added `isRealtimeAvailable()` checks before attempting WebSocket connections in:
  - `src/services/realtimeSync.ts`
  - `src/features/doctor/PatientMessagesPanel.tsx`
  - `src/features/patient-portal/SecureMessaging.tsx`
  - `src/services/queueManagement.ts`
  - `src/services/supabaseSync.ts`

## Implementation Details
- The probe uses `wss://mbhr-realtime-probe.invalid/` (reserved TLD per RFC2606) to trigger synchronous errors in restricted environments without completing a real connection
- Safari Private Browsing throws `SecurityError: The operation is insecure.` synchronously from the WebSocket constructor
- Supabase realtime sometimes surfaces these errors asynchronously after initial try/catch returns, so both sync probing and async error handlers are needed
- All realtime subscription attempts now short-circuit cleanly when WebSocket is unavailable, allowing the app to function with degraded (non-realtime) features

https://claude.ai/code/session_017X4iNThh12e9edAmN4BuSZ